### PR TITLE
TCC-14048: Addition of Payment Purpose Code to Payment API

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -7538,6 +7538,11 @@ paths:
           required: false
           type: string
           description: The name of the ultimate beneficiary if different.
+        - name: payment_purpose_code
+          in: formData
+          required: false
+          type: string
+          description: Payment Purpose Code (Mandatory for all INR payments).
         - name: on_behalf_of
           in: formData
           required: false
@@ -7899,6 +7904,11 @@ paths:
           required: false
           type: string
           description: Bulk upload reference code.
+        - name: payment_purpose_code
+          in: query
+          required: false
+          type: string
+          description: Payment Purpose Code (Mandatory for all INR payments).
         - name: page
           in: query
           required: false
@@ -8046,6 +8056,11 @@ paths:
         required: false
         type: boolean
         description: Include deleted payments.
+      - name: payment_purpose_code
+        in: query
+        required: false
+        type: string
+        description: Payment Purpose Code (Mandatory for all INR payments).
       - name: on_behalf_of
         in: query
         required: false
@@ -8331,6 +8346,11 @@ paths:
         required: false
         type: string
         description: The name of the ultimate beneficiary if different.
+      - name: payment_purpose_code
+        in: formData
+        required: false
+        type: string
+        description: Payment Purpose Code (Mandatory for all INR payments).
       - name: on_behalf_of
         in: formData
         required: false
@@ -8934,6 +8954,11 @@ paths:
           required: true
           type: string
           description: Payment UUID.
+        - name: payment_purpose_code
+          in: formData
+          required: false
+          type: string
+          description: Payment Purpose Code (Mandatory for all INR payments).
         - name: on_behalf_of
           in: formData
           required: false
@@ -16974,6 +16999,8 @@ definitions:
         type: string
       ultimate_beneficiary_name:
         type: string
+      payment_purpose_code:
+        type: string
     example:
       id: 543477161-91de-012f-e284-1e0030c7f3123
       short_reference: 140416-GGJBNQ001
@@ -16998,6 +17025,7 @@ definitions:
       unique_request_id: 1234567890abc
       failure_returned_amount: ''
       ultimate_beneficiary_name: Some beneficiary name
+      payment_purpose_code: ''
   PaymentAuthorisations:
     type: object
     description: Payment Authorisations.


### PR DESCRIPTION
From my understanding Swagger does not support optionals in the version we are using (2.0)

Please have an extra detailed review of this submitted work.