### PR TITLE
TCC-15170 Fix payment purpose code field

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -10413,7 +10413,7 @@ paths:
           description: "Legal entity type. Can be either 'company' or 'individual'."
         - name: bank_account_country
           in: query
-          required: false
+          required: true
           type: string
           description: Two-letter country code of the bank account.
       responses:


### PR DESCRIPTION
The payment purpose code field field should be "purpose_code" instead of "payment_purpose_code". Make "bank_account_country" mandatory for HTTP GET "/reference/payment_purpose_codes".