### PR TITLE
SWAGGER-25 Add FedWire routing code to VANs API

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -18559,6 +18559,8 @@ definitions:
         type: string
       routing_code:
         type: string
+      wire_routing_code:
+        type: string
       created_at:
         type: string
         format: date-time
@@ -18573,7 +18575,8 @@ definitions:
       bank_institution_name: Community Federal Savings Bank
       bank_institution_address: 'Seventh Avenue, New York, NY 10019, US'
       bank_institution_country: United States
-      routing_code: 5797480
+      routing_code: 026073150
+      wire_routing_code: 026073008
       created_at: '2014-01-12T00:00:00.000Z'
       updated_at: '2014-01-12T00:00:00.000Z'
 


### PR DESCRIPTION
…VANs: :wire_routing_code. As well as the `:routing_code` has been changed