### PR TITLE
Update reference.yaml

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -874,7 +874,7 @@ paths:
           in: formData
           required: false
           type: string
-          default: no_markup
+          default: fxcg_rfx_default
           description: The name of the spread table assigned to the account.
         - name: api_trading
           in: formData


### PR DESCRIPTION
The correct default for not setting a spread_table is 'fxcg_rfx_default' but the documentation says no_markup

https://www.currencycloud.com/developers/docs/item/create-account/

Setting no spread_table defaults to 'fxcg_rfx_default'

{     "id": "245a1ebd-d8a6-416d-bcc1-9de381d22f90",     "account_name": "My Example Account",     "brand": "currency_cloud_dev_centre",     "your_reference": null,     "status": "enabled",     "street": "My Example Street",     "city": "My Example City",     "state_or_province": null,     "country": "GB",     "postal_code": "Example Code",     "spread_table": "fxcg_rfx_default",     "legal_entity_type": "company",     "created_at": "2020-03-17T16:48:19+00:00",     "updated_at": "2020-03-17T16:48:19+00:00",     "identification_type": null,     "identification_value": null,     "short_reference": "200317-00046",     "api_trading": true,     "online_trading": true,     "phone_trading": true,     "process_third_party_funds": false,     "settlement_type": "net" }