### PR TITLE
Swagger 164 deprecate va and iban endpoints

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -7873,6 +7873,7 @@ paths:
 
   /ibans/find:
     get:
+      deprecated: true
       tags:
         - IBANs
       x-api-group: collect
@@ -14896,6 +14897,7 @@ paths:
               description: A unique reference for the request.
   /virtual_accounts/find:
     get:
+      deprecated: true
       tags:
         - VANs
       x-api-group: collect

--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -48,13 +48,13 @@ tags:
       and collect funds in each available currency
   - name: IBANs
     description: >-
-      **This endpoint is deprecated and will be removed at the end of February. Please use the Funding Account API instead.**
+      **This endpoint is deprecated and will be removed at the end of February, 2021. Please use the Funding Account API instead.**
 
       Create, search and manage International Bank Account Numbers (IBANs)
       assigned to your Currencycloud account balance or your sub-accounts'
       balances. You can also retrieve and assign IBANs to the the account.
   - name: Payers
-    description: >-
+    description: >- 
       Provides you with the ability to view information relating to the 'payer'
       for a payment that has been initiated through the platform.
   - name: Payments
@@ -85,7 +85,7 @@ tags:
       account and associated sub-accounts.
   - name: VANs
     description: >-
-      **This endpoint is deprecated and will be removed at the end of February. Please use the Funding Account API instead.**
+      **This endpoint is deprecated and will be removed at the end of February, 2021. Please use the Funding Account API instead.**
 
       Create, search and manage Virtual Accounts (VANs) assigned to your
       Currencycloud account balance or your sub-accounts' balances. You can also

--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -48,6 +48,8 @@ tags:
       and collect funds in each available currency
   - name: IBANs
     description: >-
+      **This endpoint is deprecated and will be removed at the end of February. Please use the Funding Account API instead.**
+
       Create, search and manage International Bank Account Numbers (IBANs)
       assigned to your Currencycloud account balance or your sub-accounts'
       balances. You can also retrieve and assign IBANs to the the account.
@@ -83,6 +85,8 @@ tags:
       account and associated sub-accounts.
   - name: VANs
     description: >-
+      **This endpoint is deprecated and will be removed at the end of February. Please use the Funding Account API instead.**
+
       Create, search and manage Virtual Accounts (VANs) assigned to your
       Currencycloud account balance or your sub-accounts' balances. You can also
       retrieve and assign VANs to the account.
@@ -14904,7 +14908,7 @@ paths:
       summary: Find VANs
       description: >-
         Returns a JSON structure with details of the VANs for the specified
-        accounts
+        accounts.
       operationId: FindVANs
       produces:
         - application/json


### PR DESCRIPTION
I've used markdown to display the deprecation message in bold.  Not sure if this renders properly in the dev centre?  It is fine in Swagger UI.