### PR TITLE
Fix FindContacts response type

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -5033,7 +5033,13 @@ paths:
         '200':
           description: Success.
           schema:
-            $ref: '#/definitions/Contact'
+            properties:
+              contacts:
+                type: array
+                items:
+                  $ref: '#/definitions/Contact'
+              pagination:
+                $ref: '#/definitions/Pagination'
           headers:
             X-Request-Id:
               type: string


### PR DESCRIPTION
The response type for `FindContacts` in the `reference.yaml` state `Contact` as a response where the API actually returns:

```json
{
  "contacts": [Contact],
  "pagination": ...
}
```

as stated in the doc https://www.currencycloud.com/developers/docs/item/find-contacts/