### PR TITLE
Fix get sender details id param description

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -13836,7 +13836,7 @@ paths:
           in: path
           required: true
           type: string
-          description: The Related Entity UUID (related_entity_id) for the Transaction.
+          description: The id for the Transaction to get its sender details.
         - name: on_behalf_of
           in: query
           required: false


### PR DESCRIPTION
Hi! Just recently playing w/ CurrencyCloud APIs. When [created the demo account](https://developer.currencycloud.com/register-for-an-api-key/), saw that I had a pending transaction of 100k$. Then, was testing the "Emulate inbound funds" API to see how to approve it. 

Out of curiosity, I wanted to get the sender details before doing so. And as according to the docs, did a `GET /v2/transactions/sender/{id}` request. With `{id}` being the `related_entity_id` of this sample transaction, [as the docs for that request state](https://developer.currencycloud.com/api-reference/#sender):

![image](https://user-images.githubusercontent.com/8050648/209980000-b21aedae-39e3-4a9b-8eca-cbb74e01b6d9.png)

But was surprised to get a 404 error! 

Then, after approving, I tried with `{id}` being the transaction ID whose sender I want to know about.  And it worked. So my suspicion is the docs are incorrect. 

> I'm assuming the same behaviour happens for rest of transactions, not just the sample one. And that same behaviour of this sender details API happens in production environment.

Thanks in advance :) 