### PR TITLE
WAL-3164: Remove "reason" as filter for transactions/find

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -14546,11 +14546,6 @@ paths:
             - credit
             - debit
           description: Whether the transaction debits or credits the account balance.
-        - name: reason
-          in: query
-          required: false
-          type: string
-          description: User-generated reason for payment - freeform text.
         - name: settles_at_from
           in: query
           required: false
@@ -21100,7 +21095,6 @@ definitions:
           - completed
           - deleted
           - depending
-
       reason:
         description: Reason
         type: string


### PR DESCRIPTION
Using "reason" as a filter for `transactions/find` has been deprecated.