### PR TITLE
WAL-3164: Mark as deprecated the "reason" as filter for transactions/find

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -14550,7 +14550,7 @@ paths:
           in: query
           required: false
           type: string
-          description: User-generated reason for payment - freeform text.
+          description: (DEPRECATED) User-generated reason for payment - freeform text.
         - name: settles_at_from
           in: query
           required: false


### PR DESCRIPTION
Initiate removal of the filter.