### PR TITLE
Updated existing swagger 2.0 file and adds example OPenAPI 3.0 version

### DIFF
--- a/src/reference-oas3.yaml
+++ b/src/reference-oas3.yaml
@@ -1,0 +1,24329 @@
+openapi: 3.0.3
+info:
+  description: The Currencycloud API is a robust, predictable, easy-to-use API for converting money between currencies and
+    making payments around the world. Dynamically register sub-accounts to provide white labeled money transfer services to
+    your own customers.
+  version: 2.43.0
+  title: Currencycloud API
+  termsOfService: https://www.currencycloud.com/terms-and-conditions/
+  contact:
+    name: support
+    email: support@currencycloud.com
+externalDocs:
+  description: API overview
+  url: https://www.currencycloud.com/developers/
+tags:
+- name: Authenticate
+  description: Authenticate to gain access to the API. Log in to your Currencycloud account using your API Key and log out
+    to terminate your session.
+- name: Accounts
+  description: Create, search and update your Currencycloud account and any associated sub-accounts. Also provides you with
+    the ability to use your own reference IDs for easy reconciliation with your internal systems.
+- name: Balances
+  description: Provides access to view balance information. View the balances that you currently hold in different currencies
+    on your Currencycloud account.
+- name: Beneficiaries
+  description: Create, search and manage the list of individuals or companies that you send payments to.
+- name: Contacts
+  description: Create, search and manage the list of users that have access in your Currencycloud account or associated sub-accounts.
+- name: Conversions
+  description: Find, retrieve and create a live currency conversion. You can also create and manage the live conversion of
+    funds between two currencies.
+- name: Funding
+  description: Find funding accounts that can be used to settle and collect funds in each available currency.
+- name: Payers
+  description: View information relating to the 'payer' for a payment that has been initiated through the platform.
+- name: Payments
+  description: Create, search, manage and action all of your domestic and international payments through this API.
+- name: Rates
+  description: Super fast real-time access to live foreign exchange rates through the Currencycloud platform.
+- name: Reference
+  description: Easy access to view important data relevant to your Currencycloud account including beneficiary details, conversion
+    dates, available currencies, payer required details, payment dates and settlement details.
+- name: Reporting
+  description: Ability to create and retrieve reports.
+- name: Sender
+  description: Sender of funds.
+- name: Transactions
+  description: View balances and all pending and completed transactions in your Currencycloud account, as well as associated
+    sub-account balances and transactions.
+- name: Transfers
+  description: Search, retrieve and create a transfer of funds between your Currencycloud account and associated sub-accounts.
+- name: Withdrawal Accounts
+  description: Manage withdrawal accounts
+- name: Demo
+  description: Requests that are only available in the Demo environment.
+servers:
+- url: https://devapi.currencycloud.com/v2
+  description: Development API
+paths:
+  /authenticate/api:
+    post:
+      tags:
+      - Authenticate
+      summary: Login
+      description: 'Authenticates and authorizes a user to the Currencycloud API.<br><br>
+
+        Submit a login ID and API key for a Currencycloud account, you can register for and API key <a href="https://developer.currencycloud.com/register-for-an-api-key/">here</a>.
+        A temporary authentication token is returned following a succesful login.<br><br>
+
+        The authentication token is required to make requests to all other endpoints in the Currencycloud API. Tokens expire
+        after 30 minutes of inactivity.<br><br>
+
+        Token requests are limited to 60 calls per minute.<br><br>
+
+        For security, Currencycloud accounts are disabled when four unsuccessful login attempts are made within a short period.
+        In these circumstances, account holders must <a href="mailto:support@currencycloud.com">contact support</a> to reactivate
+        their account.'
+      operationId: Login
+      x-api-group: manage
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                login_id:
+                  type: string
+                  description: The login ID for a Currencycloud account, this is usually an email address.
+                  minLength: 1
+                  maxLength: 50
+                api_key:
+                  type: string
+                  description: The unique API key for the Currencycloud account.
+                  pattern: ^[a-f0-9]{64}$
+              required:
+              - login_id
+              - api_key
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthenticationToken'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: login_id_is_required
+            category: login_id
+            message: login_id is required
+            params: ''
+          - code: login_id_is_too_short
+            category: login_id
+            message: login_id can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: login_id_is_too_long
+            category: login_id
+            message: login_id can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: api_key_is_required
+            category: api_key
+            message: api_key is required
+            params: ''
+          - code: api_key_length_is_invalid
+            category: api_key
+            message: api_key should be 64 character(s) long
+            params: '{ "length" => 64 }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporarily unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /authenticate/close_session:
+    post:
+      tags:
+      - Authenticate
+      summary: Logout
+      description: Authentication tokens expire automatically after 30 minutes of inactivity. If a session is no longer required,
+        it is good security practice to retire its authentication token early rather than leave it to time out.
+      operationId: Logout
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      responses:
+        '200':
+          description: Success. A 200 response with an empty payload signifies that the authentication token is successfully
+            retired.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/create:
+    post:
+      tags:
+      - Accounts
+      summary: Create Account
+      description: Creates a new sub-account. Returns the new account entity on success.
+      operationId: CreateAccount
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_name:
+                  type: string
+                  description: Account name.
+                  pattern: \S+
+                  minLength: 1
+                  maxLength: 150
+                legal_entity_type:
+                  type: string
+                  description: Legal entity.
+                  enum:
+                  - company
+                  - individual
+                street:
+                  type: string
+                  description: First line of address.
+                  maxLength: 150
+                city:
+                  type: string
+                  description: City
+                  maxLength: 100
+                postal_code:
+                  type: string
+                  description: Postal code. Required for sub-accounts on our outsourced KYC model, also required where country
+                    code = "US", "CA" or "MX".
+                  maxLength: 20
+                country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code.
+                  pattern: ^[A-Z]{2}$
+                brand:
+                  type: string
+                  description: The value of this field is used for white labeling the Currencycloud user interface. If nothing
+                    is specified then the account will inherit the house account's brand.
+                  minLength: 1
+                  maxLength: 255
+                your_reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                status:
+                  type: string
+                  description: Account status.
+                  enum:
+                  - disabled
+                  - enabled
+                  - enabled_no_trading
+                  default: enabled
+                state_or_province:
+                  type: string
+                  description: State or province two-letter ISO 3166 code. Only applicable to some countries, required where
+                    country code = "US", "CA" or "MX".
+                  maxLength: 100
+                spread_table:
+                  type: string
+                  description: The name of the spread table assigned to the account. This is needed if they intend to apply
+                    markup.
+                  default: flat_0.00
+                  maxLength: 100
+                api_trading:
+                  type: boolean
+                  description: Allow the account to make trades via the Currencycloud API.
+                online_trading:
+                  type: boolean
+                  description: Allow the account to make trades via Currencycloud Direct.
+                phone_trading:
+                  type: boolean
+                  description: Allow the account to make trades via phone.
+                identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the account owner. Required for individual sub-accounts
+                    on our outsourced KYC model, optional otherwise.
+                  enum:
+                  - none
+                  - others
+                  - asylum_registration_card
+                  - citizenship_papers
+                  - consular_id
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - immigration_status_document
+                  - indigenous_card
+                  - international_driving_licence
+                  - matricula_consular
+                  - municipality_identity_card
+                  - national_health_insurance_card
+                  - national_id
+                  - national_identity_card
+                  - passport
+                  - passport_card
+                  - postal_identity_card
+                  - private_operators_card
+                  - professional_qualification_card
+                  - proof_of_citizenship
+                  - registro_federal_de_contribuyentes
+                  - residence_permit
+                  - residence_status_document
+                  - service_id_card
+                  - social_insurance_number
+                  - social_security_card
+                  - social_security_number
+                  - tax_id
+                  - visa
+                  - voter_id
+                  - work_permit
+                  - incorporation_number
+                identification_value:
+                  type: string
+                  description: Unique reference code for the identification document, such as a passport number. Required
+                    if "identification_type" is provided.
+                  minLength: 1
+                  maxLength: 255
+                terms_and_conditions_accepted:
+                  type: boolean
+                  description: Acceptance of the terms and conditions. Required for sub-accounts that are on our Outsourced
+                    KYC model, optional otherwise.
+                industry_type:
+                  type: string
+                  description: The industry the account operates in. Required if "linked_account_id" is present. Required
+                    if extended compliance fields are present.
+                  maxLength: 255
+                business_website_url:
+                  type: string
+                  description: A fully qualified URL (including scheme) indicating a marketplace homepage, a link to a government
+                    page concerning the company or the literal string 'no_website_available'. Required if extended compliance
+                    fields are present.
+                  maxLength: 400
+                identification_expiration:
+                  type: string
+                  format: date
+                  description: 'The expiration date for the identification information provided. Format YYYY-MM-DD. Part of
+                    extended compliance for "legal_entity_type: individual" accounts.'
+                identification_issuer:
+                  type: string
+                  description: 'ISO country code indicating the issuer of the identification information provided. Part of
+                    extended compliance for "legal_entity_type: individual" accounts.'
+                  maxLength: 255
+                country_of_citizenship:
+                  type: string
+                  description: 'ISO country code indicating the citizenship of the individual the account belongs to. Provide
+                    the longest held citizenship for individuals with multiple. Part of extended compliance for "legal_entity_type:
+                    individual" accounts.'
+                country_of_incorporation:
+                  type: string
+                  description: 'Two-letter ISO country code indicating the country the company is incorpated in. Part of extended
+                    compliance for "legal_entity_type: company" accounts.'
+                  minLength: 2
+                  maxLength: 2
+                date_of_incorporation:
+                  type: string
+                  format: date
+                  description: 'Date of the company''s incorporation. Part of extended compliance for "legal_entity_type:
+                    company" accounts.'
+                legal_entity_sub_type:
+                  type: string
+                  description: 'The type of company this account represents. Part of extended compliance for "legal_entity_type:
+                    company" accounts.'
+                  enum:
+                  - sole_trader
+                  - limited_liability_company
+                  - public_limited_company
+                  - limited_liability_partnership
+                  - unincorporated_partnership
+                  - unregistered_charity
+                  - registered_charity
+                  - trust
+                  - company_with_nominee_shareholders_or_shares_in_bearer_form
+                  - scottish_limited_partnership
+                  - other
+                trading_address_street:
+                  type: string
+                  description: 'The street portion of the company''s trading address. Part of extended compliance for "legal_entity_type:
+                    company" accounts.'
+                  maxLength: 150
+                trading_address_city:
+                  type: string
+                  description: 'The city portion of the company''s trading address. Part of extended compliance for "legal_entity_type:
+                    company" accounts.'
+                trading_address_state:
+                  type: string
+                  description: 'The state portion of the company''s trading address. Part of extended compliance for "legal_entity_type:
+                    company" accounts.'
+                  maxLength: 100
+                trading_address_postalcode:
+                  type: string
+                  description: 'The postal code portion of the company''s trading address. Part of extended compliance for
+                    "legal_entity_type: company" accounts.'
+                  maxLength: 20
+                trading_address_country:
+                  type: string
+                  description: 'Two-letter ISO country code representing the country portion of the company''s trading address.
+                    Part of extended compliance for accounts with "legal_entity_type: company".'
+                  minLength: 2
+                  maxLength: 2
+                tax_identification:
+                  type: string
+                  description: 'Tax identification number for the company. Part of extended compliance for accounts with "legal_entity_type:
+                    company". Required for companies based in "US" or "AU".'
+                  maxLength: 100
+                national_identification:
+                  type: string
+                  description: 'National identification (e.g SSN for U.S. individuals). Part of extended compliance for "legal_entity_type:
+                    individual" accounts. Required for "US" based companies.'
+                  maxLength: 100
+                customer_risk:
+                  type: string
+                  description: 'The risk classification for this account''s expected behaviour. Part of extended compliance
+                    for "legal_entity_type: individual | company" accounts.'
+                  enum:
+                  - LOW
+                  - MEDIUM
+                  - HIGH
+                expected_monthly_activity_volume:
+                  type: number
+                  description: 'The expected number of money moving actions this account will conduct monthly. Part of extended
+                    compliance for "legal_entity_type: individual | company" accounts.'
+                expected_monthly_activity_value:
+                  type: number
+                  description: 'The expected sum value of money moving actions this account will conduct monthly. The currency
+                    basis of the value is submitted as part of "expected_transaction_currencies". Part of extended compliance
+                    for "legal_entity_type: individual | company" accounts.'
+                expected_transaction_currencies[]:
+                  type: array
+                  description: 'An array holding a single ISO currency code for the expected currency this account will mainly
+                    transact in. Part of extended compliance for "legal_entity_type: individual | company" accounts.'
+                  items:
+                    type: string
+                expected_transaction_countries[]:
+                  type: array
+                  description: Array of two-letter ISO-3166 country codes indicating the countries this account is expected
+                    to transact to and from.
+                  items:
+                    type: string
+                    minLength: 2
+                    maxLength: 2
+              required:
+              - account_name
+              - legal_entity_type
+              - street
+              - city
+              - country
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_name_is_too_short
+            category: account_name
+            message: account_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: account_name_is_too_long
+            category: account_name
+            message: account_name can not be longer than 150 character(s)
+            params: '{ "maxlength" => 150 }'
+          - code: account_name_is_required
+            category: account_name
+            message: account_name is required
+            params: ''
+          - code: brand_is_too_short
+            category: brand
+            message: brand can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: brand_is_too_long
+            category: brand
+            message: brand can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: brand_not_found
+            category: brand
+            message: Brand non_existing_brand wasn't found
+            params: '{ "brand" => "non_existing_brand" }'
+          - code: brand_account_not_broker
+            category: brand
+            message: Account doesn't have broker permissions
+            params: '{ "brand" => "wrong_brand" }'
+          - code: your_reference_is_too_long
+            category: your_reference
+            message: your_reference can not be longer than 25 character(s)
+            params: '{ "maxlength" => 25 }'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: enabled, disabled, enabled_no_trading'
+            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+          - code: legal_entity_type_not_in_range
+            category: legal_entity_type
+            message: 'legal_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: legal_entity_type_is_required
+            category: legal_entity_type
+            message: Legal entity type is required
+            params: ''
+          - code: street_is_too_long
+            category: street
+            message: street can not be longer than 150 character(s)
+            params: '{ "maxlength" => 150 }'
+          - code: street_is_required
+            category: street
+            message: Street is required
+            params: ''
+          - code: city_is_too_long
+            category: city
+            message: city can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: city_is_required
+            category: city
+            message: City is required.
+            params: ''
+          - code: postal_code_is_too_long
+            category: postal_code
+            message: postal_code can not be longer than 20 character(s)
+            params: '{ "maxlength" => 20 }'
+          - code: postal_code_is_required
+            category: postal_code
+            message: Postal code is required.
+            params: ''
+          - code: state_or_province_is_too_long
+            category: state_or_province
+            message: state_or_province can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: country_is_in_invalid_format
+            category: country
+            message: country is not a valid ISO 3166-1 Alpha-2 country code
+            params: '{ "maxlength" => 2 }'
+          - code: country_is_required
+            category: country
+            message: Country is required
+            params: ''
+          - code: spread_table_is_too_long
+            category: spread_table
+            message: spread_table can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: identification_type_is_missing
+            category: identification_type
+            message: identification_type is missing
+            params: ''
+          - code: identification_type_is_invalid
+            category: identification_type
+            message: identification_type is invalid
+            params: ''
+          - code: identification_value_is_missing
+            category: identification_value
+            message: identification_value is missing
+            params: ''
+          - code: identification_value_is_invalid
+            category: identification_value
+            message: identification_value is invalid
+            params: ''
+          - code: state_or_province_is_required
+            category: state_or_province
+            message: State or province is required for US, CA and MX
+            params: ''
+          - code: terms_and_conditions_accepted_is_required
+            category: terms_and_conditions_accepted
+            message: Terms and conditions accepted is required
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateAccountError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/{id}:
+    get:
+      tags:
+      - Accounts
+      summary: Get Account
+      description: Gets an account or sub-account owned by the authenticated user.
+      operationId: GetAccount
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Account UUID, returned by the create account endpoint.
+        required: true
+        schema:
+          type: string
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: account_not_found
+            category: id
+            message: Account was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAccountError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+    post:
+      tags:
+      - Accounts
+      summary: Update Account
+      description: Updates a sub-account owned by the authenticated user. The updated account entity is returned on success.
+      operationId: UpdateAccount
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+      - name: id
+        in: path
+        description: Account UUID, returned by the create account endpoint.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_name:
+                  type: string
+                  description: Account name.
+                legal_entity_type:
+                  type: string
+                  description: Legal entity.
+                  enum:
+                  - company
+                  - individual
+                brand:
+                  type: string
+                  description: The value of this field is used for white labeling the Currencycloud user interface.
+                your_reference:
+                  type: string
+                  description: User-generated reference code.
+                status:
+                  type: string
+                  description: Status of the account.
+                  enum:
+                  - disabled
+                  - enabled
+                  - enabled_no_trading
+                  default: enabled
+                street:
+                  type: string
+                  description: First line of address.
+                city:
+                  type: string
+                  description: City name
+                state_or_province:
+                  type: string
+                  description: State or province two-letter ISO 3166 code. Only applicable to some countries.
+                postal_code:
+                  type: string
+                  description: Postal code.
+                country:
+                  type: string
+                  description: Two-letter ISO country code.
+                spread_table:
+                  type: string
+                  description: The name of the spread table assigned to the account.
+                  default: fxcg_rfx_default
+                api_trading:
+                  type: boolean
+                  description: Whether trading via the Currencycloud API is to be enabled on the account.
+                  default: true
+                online_trading:
+                  type: boolean
+                  description: Enable online trading on the account.
+                  default: true
+                phone_trading:
+                  type: boolean
+                  description: Enable phone trading on the account.
+                  default: true
+                identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the account owner.
+                  enum:
+                  - none
+                  - others
+                  - asylum_registration_card
+                  - citizenship_papers
+                  - consular_id
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - immigration_status_document
+                  - indigenous_card
+                  - international_driving_licence
+                  - matricula_consular
+                  - municipality_identity_card
+                  - national_health_insurance_card
+                  - national_id
+                  - national_identity_card
+                  - passport
+                  - passport_card
+                  - postal_identity_card
+                  - private_operators_card
+                  - professional_qualification_card
+                  - proof_of_citizenship
+                  - registro_federal_de_contribuyentes
+                  - residence_permit
+                  - residence_status_document
+                  - service_id_card
+                  - social_insurance_number
+                  - social_security_card
+                  - social_security_number
+                  - tax_id
+                  - visa
+                  - voter_id
+                  - work_permit
+                  - incorporation_number
+                identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  maxLength: 255
+                terms_and_conditions_accepted:
+                  type: boolean
+                  description: Acceptance of the terms and conditions.
+                identification_expiration:
+                  type: string
+                  format: date
+                  description: 'The expiration date for the identification information provided. Format YYYY-MM-DD. Part of
+                    extended compliance for "legal_entity_type: individual" accounts.'
+                identification_issuer:
+                  type: string
+                  description: 'ISO country code indicating the issuer of the identification information provided. Part of
+                    extended compliance for "legal_entity_type: individual" accounts.'
+                  maxLength: 255
+                legal_entity_sub_type:
+                  type: string
+                  description: 'The type of company this account represents. Part of extended compliance for "legal_entity_type:
+                    company" accounts'
+                  enum:
+                  - sole_trader
+                  - limited_liability_company
+                  - public_limited_company
+                  - limited_liability_partnership
+                  - unincorporated_partnership
+                  - unregistered_charity
+                  - registered_charity
+                  - trust
+                  - company_with_nominee_shareholders_or_shares_in_bearer_form
+                  - scottish_limited_partnership
+                  - other
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: at_least_one_parameter
+            category: base
+            message: 'At least one parameter should be present: account_name, brand, your_reference, status, street, city,
+              state_or_province, postal_code, country, spread_table, legal_entity_type, identification_type, identification_value,
+              api_trading, online_trading, phone_trading or terms_and_conditions_accepted.'
+            params: '{ account_name, brand, your_reference, status, street, city, state_or_province, postal_code, country,
+              spread_table, legal_entity_type, identification_type, identification_value, api_trading, online_trading, phone_trading,
+              terms_and_conditions_accepted }'
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: account_name_is_too_short
+            category: account_name
+            message: account_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1}'
+          - code: account_name_is_too_long
+            category: account_name
+            message: account_name can not be longer than 150 character(s)
+            params: '{ "maxlength" => 150 }'
+          - code: account_name_is_in_invalid_format
+            category: account_name
+            message: account_name is in invalid format
+            params: ''
+          - code: brand_is_too_long
+            category: brand
+            message: brand can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: brand_not_found
+            category: brand
+            message: Brand non_existing_brand wasn't found
+            params: '{ "brand" => "non_existing_brand" }'
+          - code: brand_account_not_broker
+            category: brand
+            message: Account doesn't have broker permissions
+            params: '{ "brand" => "wrong_brand" }'
+          - code: permission_denied
+            category: permissions
+            message: Permission denied
+            params: ''
+          - code: your_reference_is_too_long
+            category: your_reference
+            message: your_reference can not be longer than 25 character(s)
+            params: '{ "maxlength" => 25 }'
+          - code: legal_entity_type_not_in_range
+            category: legal_entity_type
+            message: 'legal_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: enabled, disabled, enabled_no_trading'
+            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+          - code: street_is_too_long
+            category: street
+            message: street can not be longer than 150 character(s)
+            params: '{ "maxlength" => 150 }'
+          - code: city_is_too_long
+            category: city
+            message: city can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: postal_code_is_too_long
+            category: postal_code
+            message: postal_code can not be longer than 20 character(s)
+            params: '{ "maxlength" => 20 }'
+          - code: state_or_province_is_too_long
+            category: state_or_province
+            message: state_or_province can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: country_is_in_invalid_format
+            category: country
+            message: country is not a valid ISO 3166-1 Alpha-2 country code
+            params: '{ "type" => "country_code" }'
+          - code: spread_table_is_too_long
+            category: spread_table
+            message: spread_table can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: identification_type_is_missing
+            category: identification_type
+            message: identification_type is missing
+            params: ''
+          - code: identification_type_not_in_range
+            category: identification_type
+            message: 'identification_type should be in range: none, drivers_license, social_security_number, green_card, passport,
+              visa, matricula_consular, registro_federal_de_contribuyentes, credential_de_elector, social_insurance_number,
+              citizenship_papers, drivers_license_canadian, existing_credit_card_details, employer_identification_number,
+              national_id, others, incorporation_number, clave_unica_de_registro_de_poblacion'
+            params: '{ "range": "none, drivers_license, social_security_number, green_card, passport, visa, matricula_consular,
+              registro_federal_de_contribuyentes, credential_de_elector, social_insurance_number, citizenship_papers, drivers_license_canadian,
+              existing_credit_card_details, employer_identification_number, national_id, others, incorporation_number, clave_unica_de_registro_de_poblacion"
+              }'
+          - code: identification_type_is_invalid
+            category: identification_type
+            message: identification_type is invalid
+            params: ''
+          - code: identification_value_is_missing
+            message: identification_value is missing
+            category: identification_value
+            params: ''
+          - code: identification_value_is_invalid
+            category: identification_value
+            message: identification_value is invalid
+            params: ''
+          - code: identification_value_is_too_short
+            category: identification_value
+            message: identification_value can not be shorter than 1 character(s)
+            params: ' { "minlength": 1 }'
+          - code: editing_address_not_allowed
+            category: address
+            message: You cannot edit address information. Please contact support for additional information
+            params: ''
+          - code: editing_country_not_allowed
+            category: country
+            message: You cannot edit country. Please contact support for additional information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateAccountError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/{id}/compliance_settings:
+    get:
+      tags:
+      - Accounts
+      summary: Get Account's Compliance Settings
+      description: Gets the compliance settings for the account with the given ID.
+      operationId: GetAccountComplianceSettings
+      x-api-group: manage
+      x-throttling-tier: Unlimited
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Account UUID, returned by the create account endpoint.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountComplianceSettings'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: account_not_found
+            category: id
+            message: Account was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAccountComplianceSettingsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+    post:
+      tags:
+      - Accounts
+      summary: Update Account's Compliance Settings
+      description: Update the compliance settings for a sub-account owned by the authenticating user. On success, returns
+        the updated account entity.
+      operationId: UpdateAccountComplianceSettings
+      x-api-group: manage
+      x-throttling-tier: Unlimited
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Account UUID.
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                industry_type:
+                  type: string
+                  description: String describing the account's main industry. See merchant category codes for examples.
+                  maxLength: 255
+                country_of_incorporation:
+                  type: string
+                  description: 'Two-letter ISO-3166 Country Code indicating the country the account is incorporated in. Should
+                    only be present for ''legal_entity_type: company'' accounts.'
+                  minLength: 2
+                  maxLength: 2
+                date_of_incorporation:
+                  type: string
+                  format: date
+                  description: 'The date of the account''s incorporation. Should only be present for ''legal_entity_type:
+                    company'' accounts.'
+                business_website_url:
+                  type: string
+                  description: A fully qualified URL (including scheme) indicating a marketplace homepage, a link to a government
+                    page concerning the company or the literal string 'no_website_available'.
+                  maxLength: 400
+                expected_transaction_countries[]:
+                  type: array
+                  description: Array of two-letter ISO-3166 country codes indicating the countries this account is expected
+                    to transact to and from.
+                  items:
+                    type: string
+                    minLength: 2
+                    maxLength: 2
+                expected_transaction_currencies[]:
+                  type: array
+                  description: Array of ISO-4217 currency codes that these accounts will transact with. Limited to a single
+                    item.
+                  items:
+                    type: string
+                expected_monthly_activity_volume:
+                  type: integer
+                  format: int32
+                  description: The number of transactions this account is expected to conduct.
+                expected_monthly_activity_value:
+                  type: number
+                  format: float
+                  description: The value of transactions this account is expected to conduct. The currency for this is the
+                    single item in 'expected_transaction_currencies'.
+                tax_identification:
+                  type: string
+                  description: 'A tax identification value for companies in the United States or Australia; determined by
+                    ''accounts.country''. Should only be present for ''legal_entity_type: company'' accounts.'
+                  maxLength: 100
+                national_identification:
+                  type: string
+                  description: 'A national identification value for an individual in the United States; determined by ''accounts.country''.
+                    Should only be present for ''legal_entity_type: individual'' accounts.'
+                  maxLength: 100
+                country_of_citizenship:
+                  type: string
+                  description: 'Two-letter ISO-3166 country code for an individual''s citizenship. Should only be provided
+                    for ''legal_entity_type: individual'' accounts.'
+                  minLength: 2
+                  maxLength: 2
+                trading_address_street:
+                  type: string
+                  description: 'The street address of the company''s trading location. Should only be provided for ''legal_entity_type:
+                    company'' accounts.'
+                  maxLength: 150
+                trading_address_city:
+                  type: string
+                  description: 'The city of the company''s trading location. Should only be present for ''legal_entity_type:
+                    company'' accounts.'
+                  maxLength: 100
+                trading_address_state:
+                  type: string
+                  description: 'The state of the company''s trading location. Should only be present for ''legal_entity_type:
+                    company'' accounts.'
+                  maxLength: 100
+                trading_address_postalcode:
+                  type: string
+                  description: 'The postal code of the company''s trading location. Should only be present for ''legal_entity_type:
+                    company'' accounts.'
+                  maxLength: 20
+                trading_address_country:
+                  type: string
+                  description: 'Two-letter ISO-3166 country code representing the country portion of the company''s trading
+                    location. Should only be provided for ''legal_entity_type: company'' accounts.'
+                  minLength: 2
+                  maxLength: 2
+                customer_risk:
+                  type: string
+                  description: Risk classification for this account's expected behaviour, required for individuals and companies
+                    on the Correspondent or OKYC service model.
+                  enum:
+                  - LOW
+                  - MEDIUM
+                  - HIGH
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountComplianceSettings'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: business_website_url_is_required
+            category: business_website_url
+            message: business_website_url is required
+            params: ''
+          - code: business_website_url_is_not_permitted
+            category: business_website_url
+            message: business_website_url is not permitted
+            params: ''
+          - code: date_of_incorporation_is_required
+            category: date_of_incorporation
+            message: date_of_incorporation is required
+            params: ''
+          - code: date_of_incorporation_is_not_permitted
+            category: date_of_incorporation
+            message: date_of_incorporation is not permitted
+            params: ''
+          - code: country_of_incorporation_is_required
+            category: country_of_incorporation
+            message: country_of_incorporation is required
+            params: ''
+          - code: country_of_incorporation_is_not_permitted
+            category: country_of_incorporation
+            message: country_of_incorporation is not permitted
+            params: ''
+          - code: country_of_citizenship_is_required
+            category: country_of_citizenship
+            message: country_of_citizenship is required
+            params: ''
+          - code: country_of_citizenship_is_not_permitted
+            category: country_of_citizenship
+            message: country_of_citizenship is not permitted
+            params: ''
+          - code: expected_monthly_activity_volume_must_be_a_number_greater_than_zero
+            category: expected_monthly_activity_volume_
+            message: expected_monthly_activity_volume must be a number greater than zero
+            params: ''
+          - code: expected_monthly_activity_value_must_be_a_number_greater_than_zero
+            category: expected_monthly_activity_value
+            message: expected_monthly_activity_value must be a number greater than zero
+            params: ''
+          - code: expected_transaction_currencies_is_required
+            category: expected_transaction_currencies
+            message: expected_transaction_currencies is required
+            params: ''
+          - code: expected_transaction_countries_is_required
+            category: expected_transaction_countries
+            message: expected_transaction_countries is required
+            params: ''
+          - code: industry_type_is_required
+            category: industry_type
+            message: industry_type is required
+            params: ''
+          - code: industry_type_is_not_permitted
+            category: industry_type
+            message: industry_type is not permitted
+            params: ''
+          - code: trading_address_street_is_required
+            category: trading_address_street
+            message: trading_address_street is required
+            params: ''
+          - code: trading_address_city_is_required
+            category: trading_address_city
+            message: trading_address_city is required
+            params: ''
+          - code: trading_address_postalcode_is_required
+            category: trading_address_postalcode
+            message: trading_address_postalcode is required
+            params: ''
+          - code: trading_address_state_is_required
+            category: trading_address_state
+            message: trading_address_state is required
+            params: ''
+          - code: trading_address_country_is_required
+            category: trading_address_country
+            message: trading_address_country is required
+            params: ''
+          - code: trading_address_street_is_not_permitted
+            category: trading_address_street
+            message: trading_address_street is not permitted
+            params: ''
+          - code: trading_address_city_is_not_permitted
+            category: trading_address_city
+            message: trading_address_city is not permitted
+            params: ''
+          - code: trading_address_postalcode_is_not_permitted
+            category: trading_address_postalcode
+            message: trading_address_postalcode is not permitted
+            params: ''
+          - code: trading_address_state_is_not_permitted
+            category: trading_address_state
+            message: trading_address_state is not permitted
+            params: ''
+          - code: trading_address_country_is_not_permitted
+            category: trading_address_country
+            message: trading_address_country is not permitted
+            params: ''
+          - code: trading_address_state_invalid_state
+            category: trading_address_state
+            message: trading_address_state invalid state
+            params: ''
+          - code: tax_identification_is_required
+            category: tax_identification
+            message: tax_identification is required
+            params: ''
+          - code: tax_identification_is_not_permitted
+            category: tax_identification
+            message: tax_identification is not permitted
+            params: ''
+          - code: national_identification_is_required
+            category: national_identification
+            message: national_identification is required
+            params: ''
+          - code: national_identification_is_not_permitted
+            category: national_identification
+            message: national_identification is not permitted
+            params: ''
+          - code: customer_risk_is_required
+            category: customer_risk
+            message: customer_risk is required
+            params: ''
+          - code: customer_risk_invalid_value
+            category: customer_risk
+            message: customer_risk invalid value
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateAccountComplianceSettingsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/current:
+    get:
+      tags:
+      - Accounts
+      summary: Get Authenticating Account
+      description: Gets the authenticated user's main account.
+      operationId: GetAuthenticatingAccount
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/find:
+    post:
+      tags:
+      - Accounts
+      summary: Find Accounts
+      description: Returns account and any sub-accounts owned by the authenticated user. Optionally filter by account status
+        and other criteria.
+      operationId: FindAccountsPost
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_name:
+                  type: string
+                  description: Account name.
+                  pattern: \S+
+                  minLength: 1
+                  maxLength: 150
+                brand:
+                  type: string
+                  description: The value of this field is used for white labeling the Currencycloud user interface.
+                  minLength: 1
+                  maxLength: 255
+                your_reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                status:
+                  type: string
+                  description: Account status.
+                  enum:
+                  - disabled
+                  - enabled
+                  - enabled_no_trading
+                street:
+                  type: string
+                  description: First line of address.
+                  maxLength: 150
+                city:
+                  type: string
+                  description: City.
+                  maxLength: 100
+                state_or_province:
+                  type: string
+                  description: State or province two-letter ISO 3166 code. Only applicable to some countries.
+                  maxLength: 100
+                postal_code:
+                  type: string
+                  description: Postal code.
+                  maxLength: 20
+                country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter country code.
+                  pattern: ^[A-Z]{2}$
+                spread_table:
+                  type: string
+                  description: The name of the spread table assigned to the account.
+                  maxLength: 100
+                bank_account_verified:
+                  type: string
+                  description: Has the bank account been verified?
+                  enum:
+                  - 'yes'
+                  - 'no'
+                  - 'not required'
+                page:
+                  type: integer
+                  description: Page number.
+                  pattern: ^\d+$
+                per_page:
+                  type: integer
+                  description: Number of results per page.
+                  pattern: ^\d+$
+                order:
+                  type: string
+                  description: Any field name to change the sort order.
+                  minLength: 1
+                  maxLength: 255
+                order_asc_desc:
+                  type: string
+                  description: Sort records in ascending or descending order.
+                  enum:
+                  - asc
+                  - desc
+                  default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  accounts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Account'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_name_is_too_short
+            category: account_name
+            message: account_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: account_name_is_too_long
+            category: account_name
+            message: The account_name can not be longer than 150 character(s)
+            params: '{ "maxlength" => 150 }'
+          - code: brand_is_too_short
+            category: brand
+            message: brand can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: brand_is_too_long
+            category: brand
+            message: brand can not be longer than 100 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: your_reference_is_too_short
+            category: your_reference
+            message: your_reference can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: your_reference_is_too_long
+            category: your_reference
+            message: your_reference can not be longer than 25 character(s)
+            params: '{ "maxlength" => 25 }'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: enabled, disabled, enabled_no_trading'
+            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+          - code: invalid_extra_parameters
+            category: legal_entity_type
+            message: 'Invalid extra parameters: ${legal_entity_type}'
+            params: ''
+          - code: street_is_too_long
+            category: street
+            message: street can not be longer than 150 character(s)
+            params: '{ "maxlength" => 150 }'
+          - code: city_is_too_long
+            category: city
+            message: city can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: postal_code_is_too_long
+            category: postal_code
+            message: postal_code can not be longer than 20 character(s)
+            params: '{ "maxlength" => 20 }'
+          - code: country_is_in_invalid_format
+            category: country
+            message: country is not a valid ISO 3166-1 Alpha-2 country code
+            params: '{ "type" => "country_code" }'
+          - code: spread_table_is_too_short
+            category: spread_table
+            message: spread_table can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: spread_table_is_too_long
+            category: spread_table
+            message: spread_table can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: bank_account_verified_not_in_range
+            category: bank_account_verified
+            message: 'bank_account_verified should be in range: yes, no, not required'
+            params: '{ "range" => "yes, no, not required" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindAccountsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/{account_id}/payment_charges_settings:
+    get:
+      tags:
+      - Accounts
+      summary: Get Payment Charges Settings
+      description: Retrieves the Payment Charges Settings for the given account.
+      operationId: GetAccountPaymentChargesSettings
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: account_id
+        in: path
+        description: A UUID of a sub-account or house account visible to the authenticated user.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payment_charges_settings:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/AccountPaymentChargesSetting'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: account_id
+            message: id should be in UUID format
+            params: ''
+          - code: account_not_found
+            category: account_id
+            message: Account was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAccountPaymentChargesSettingsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /accounts/{account_id}/payment_charges_settings/{charge_settings_id}:
+    post:
+      tags:
+      - Accounts
+      summary: Manage Account Payment Charges Settings
+      description: Manage a given account's Payment Charge Settings (enable, disable, set as default).
+      operationId: ManageAccountPaymentChargesSettings
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: account_id
+        in: path
+        description: Account UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: charge_settings_id
+        in: path
+        description: Account Payment Charges Setting UUID. Can be retrieved via appropriate GET call for the given Account
+          UUID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable or disable the given Account Payment Charges Setting.
+                default:
+                  type: boolean
+                  description: Set the given Account Payment Charges Setting as default. This will be used when the 'charge_type'
+                    parameter is not specified for a payment.
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPaymentChargesSetting'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: account_id
+            message: id should be in UUID format
+            params: ''
+          - code: account_not_found
+            category: account_id
+            message: Account was not found for this id
+            params: ''
+          - code: permission_denied
+            category: permissions
+            message: You do not have permission 'payment_charges_management' to perform this operation
+            params: ''
+          - code: edit_not_allowed
+            category: permission
+            message: You are not allowed to change your 'payment_charges_settings'. In order to be enabled for additional
+              type(s) of payment charges please contact Customer Support
+            params: ''
+          - code: banking_charges_settings_not_found
+            category: charge_settings_id
+            message: Bank Charges Settings were not found for the provided ChargeSettingsId
+            params: ''
+          - code: unavailable_charge_type
+            category: permission
+            message: You are not enabled to switch on these type of charges. In order to be enabled for this option - please
+              contact Customer Support
+            params: ''
+          - code: disable_and_default_charge_not_allowed
+            category: invalid_value
+            message: You cannot disable and then default setting
+            params: ''
+          - code: default_disabled_charge_not_allowed
+            category: invalid_value
+            message: You cannot default disabled setting
+            params: ''
+          - code: disable_default_charge_not_allowed
+            category: invalid_value
+            message: You can not disable default settings
+            params: ''
+          - code: set_default_to_false_not_allowed
+            category: invalid_value
+            message: You cannot disable a default charge type. Please update the charge type not to be default and then disable
+              it
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ManageAccountPaymentChargesSettingsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /terms_and_conditions/accept:
+    post:
+      tags:
+      - Accounts
+      summary: Accept Terms of Use
+      description: Endpoint for accounts using our Outsourced KYC model to accept Terms of Use.
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                type:
+                  type: string
+                  description: The type of Terms of Use the user is accepting.
+                  enum:
+                  - VGSI
+                version:
+                  type: string
+                  description: The version of the Terms of Use the user is accepting.
+                  enum:
+                  - '1.0'
+                reference_type:
+                  type: string
+                  description: The type of reference accepting the Terms of Use.
+                  enum:
+                  - ACCOUNT
+                reference_id:
+                  type: string
+                  format: uuid
+                  description: The account / sub-account UUID that the Terms of Use are being accepted for.
+                first_name:
+                  type: string
+                  description: The first name of the user accepting the Terms of Use. Must be between 1 and 100 characters
+                    in length and not contain < or >.
+                  minLength: 1
+                  maxLength: 100
+                last_name:
+                  type: string
+                  description: The last name of the user accepting the Terms of Use. Must be between 1 and 100 characters
+                    in length and not contain < or >.
+                  minLength: 1
+                  maxLength: 100
+                email:
+                  type: string
+                  description: 'The email of the user accepting the Terms of Use. Length must be between 6 and 255 characters.
+                    <br> Regex:  /^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$/'
+                  pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
+                  minLength: 6
+                  maxLength: 255
+              required:
+              - type
+              - version
+              - reference_type
+              - reference_id
+              - first_name
+              - last_name
+              - email
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AcceptTermsResponse'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: accept_terms_and_conditions_invalid
+            message: Parameters are invalid or missing when required
+            params: ''
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Contact ID or Terms of Use type not found
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /balances/{currency}:
+    get:
+      tags:
+      - Balances
+      summary: Get Balance
+      description: Gets the balance for a currency from the account of the authenticated user.
+      operationId: GetBalance
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: currency
+        in: path
+        description: Three-letter ISO currency code.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Balance'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_currency
+            category: currency
+            message: XYZ is not a valid ISO 4217 currency code
+            params: '{ "currency" => "XYZ" }'
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: on_behalf_of_is_not_valid_uuid
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: unsupported_currency
+            category: currency
+            message: Unsupported currency XYZ
+            params: '{ "currency": "UAH" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetBalanceError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /balances/find:
+    get:
+      tags:
+      - Balances
+      summary: Find Balances
+      description: Searches for currency balances in the main account or a sub-account owned by the authenticated user.
+      operationId: FindBalances
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: amount_from
+        in: query
+        description: Minimum balance amount.
+        required: false
+        schema:
+          type: number
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_to
+        in: query
+        description: Maximum balance amount.
+        required: false
+        schema:
+          type: number
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: as_at_date
+        in: query
+        description: A valid ISO 8601 format, e.g. "2019-12-31T23:59:59".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: scope
+        in: query
+        description: '"Own" account, "clients" sub-accounts, or "all" accounts.'
+        required: false
+        schema:
+          type: string
+          enum:
+          - all
+          - clients
+          - own
+          default: own
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: A field name to change the sort order - "created_at", "amount", "updated_at" or "currency".
+        required: false
+        schema:
+          type: string
+          enum:
+          - amount
+          - created_at
+          - currency
+          - updated_at
+          default: created_at
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  balances:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Balance'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: as_at_date_is_in_invalid_format
+            category: as_at_date
+            message: as_at_date should be in ISO 8601 format
+            params: '{ "type": "datetime" }'
+          - code: amount_from_type_is_wrong
+            category: amount_from_type
+            message: amount_from should be of decimal type
+            params: '{"type": "decimal"}'
+          - code: amount_to_type_is_wrong
+            category: amount_to_type
+            message: amount_to should be of decimal type
+            params: '{"type": "decimal"}'
+          - code: order_not_in_range
+            category: order
+            message: 'order should be in range: created_at, amount, updated_at, currency'
+            params: '{"range": "created_at, amount, updated_at, currency"}'
+          - code: order_asc_desc_not_in_range
+            category: order_asc_desc
+            message: 'order_asc_desc should be in range: asc, desc'
+            params: '{"range": "asc, desc"}'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindBalancesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /balances/top_up_margin:
+    post:
+      tags:
+      - Balances
+      summary: Top Up Margin Balance
+      description: Tops up the margin balance.
+      operationId: TopUpMarginBalance
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-letter ISO currency code for the currency to top up.
+                  pattern: ^[A-Z]{3}$
+                amount:
+                  type: string
+                  description: Amount to top up.
+                  pattern: ^\d+(\.\d{1,3})?$
+                on_behalf_of:
+                  type: string
+                  format: UUID
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                  minLength: 36
+                  maxLength: 36
+              required:
+              - currency
+              - amount
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopUpMarginBalance'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: amount_is_required
+            category: amount
+            message: amount is required
+            params: ''
+          - code: amount_type_is_wrong
+            category: amount
+            message: amount should be of numeric_greater_than_zero type
+            params: '{ "type" => "numeric_greater_than_zero" }'
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_is_not_valid_uuid
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopUpMarginBalanceError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /beneficiaries/find:
+    post:
+      tags:
+      - Beneficiaries
+      summary: Find Beneficiaries
+      description: Returns beneficiaries attached to the account or any sub-account owned by the authenticated user.
+      operationId: FindBeneficiariesPost
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                bank_account_holder_name:
+                  type: string
+                  description: Bank account holder's name.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code. If the beneficiary is a company, this is the country in which
+                    the company is registered. If the beneficiary is an individual, this is the country in which the beneficiary
+                    is based.
+                  pattern: ^[A-Z]{2}$
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which money is held in the beneficiary's bank account. Three-letter currency code.
+                  pattern: ^[A-Z]{3}$
+                account_number:
+                  type: string
+                  description: Bank account number.
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type[0]:
+                  type: string
+                  description: Local payment routing system. If supplied, a value for routing_code_value[0] must also be supplied.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value[0]:
+                  type: string
+                  description: The value for any routing system specified in routing_code_type[0]. If supplied, a value for
+                    routing_code_type[0] must also be supplied.
+                  minLength: 1
+                  maxLength: 50
+                bic_swift:
+                  type: string
+                  description: BIC/Swift code
+                  pattern: ^(\w{8}|\w{11})$
+                iban:
+                  type: string
+                  description: IBAN code
+                  pattern: ([A-Z0-9]\s*){15,34}
+                default_beneficiary:
+                  type: boolean
+                  description: Payments are made automatically to default beneficiaries when a beneficiary is not specified.
+                bank_name:
+                  type: string
+                  description: Bank name
+                  minLength: 1
+                bank_account_type:
+                  type: string
+                  description: Bank account type.
+                  enum:
+                  - checking
+                  - savings
+                name:
+                  type: string
+                  description: Beneficiary's name.
+                  pattern: \S+
+                  minLength: 1
+                  maxLength: 100
+                beneficiary_entity_type:
+                  type: string
+                  description: Beneficiary's legal entity type - individual or company.
+                  enum:
+                  - company
+                  - individual
+                beneficiary_company_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "company".
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_first_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_last_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_city:
+                  type: string
+                  description: City
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_postcode:
+                  type: string
+                  description: Post code
+                  maxLength: 12
+                beneficiary_state_or_province:
+                  type: string
+                  description: State or province.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_date_of_birth:
+                  type: string
+                  format: date
+                  description: If "beneficiary_entity_type" is "company", date of registration. If "beneficiary_entity_type"
+                    is "individual", date of birth. ISO 8601 format YYYY-MM-DD.
+                scope:
+                  type: string
+                  description: Search "own" account, "clients" sub-accounts, or "all" accounts.
+                  enum:
+                  - all
+                  - clients
+                  - own
+                  default: own
+                page:
+                  type: integer
+                  description: Page number
+                  pattern: ^\d+$
+                per_page:
+                  type: integer
+                  description: Number of results per page.
+                  pattern: ^\d+$
+                order:
+                  type: string
+                  description: Any field name to change the sort order.
+                  minLength: 1
+                  maxLength: 255
+                order_asc_desc:
+                  type: string
+                  description: Sort records in ascending or descending order.
+                  enum:
+                  - asc
+                  - desc
+                  default: asc
+                beneficiary_external_reference:
+                  type: string
+                  description: Beneficiary external reference.
+                  minLength: 1
+                  maxLength: 255
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  beneficiaries:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Beneficiary'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: bank_account_holder_name_is_too_short
+            category: bank_account_holder_name
+            message: bank_account_holder_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_account_holder_name_is_too_long
+            category: bank_account_holder_name
+            message: bank_account_holder_name can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_country_is_in_invalid_format
+            category: beneficiary_country
+            message: beneficiary_country is in invalid format
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is in invalid format
+            params: ''
+          - code: bank_name_is_too_short
+            category: bank_name
+            message: bank_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_account_type_not_in_range
+            category: bank_account_type
+            message: 'bank_account_type should be in range: checking, savings'
+            params: '{ "range" => "checking, savings" }'
+          - code: account_number_is_too_short
+            category: account_number
+            message: account_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: account_number_is_too_long
+            category: account_number
+            message: account_number can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: incorrect_mapping
+            category: base
+            message: Following parameters must have same keys
+            params: '{ "parameters" => "routing_code_value,routing_code_type" }'
+          - code: routing_code_type_is_too_short
+            category: routing_code_type
+            message: routing_code_type can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1, "indices" => ["0", "1"] }'
+          - code: routing_code_type_is_too_long
+            category: routing_code_type
+            message: routing_code_type can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50, "indices" => ["0", "1"] }'
+          - code: routing_code_type_not_included_in_list
+            category: routing_code_type
+            message: One or more of routing_code_type items are not included in list
+            params: '{ "list" => "sort_code,bsb_code,institution_no,bank_code,branch_code,aba,clabe }'
+          - code: beneficiary_date_of_birth_type_is_wrong
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: beneficiary_date_of_birth_is_earlier
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be later than 1900-01-01
+            params: '{ "min_date" => "1900-01-01" }'
+          - code: beneficiary_date_of_birth_is_after
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be earlier than todays date
+            params: '{ "max_date" => "Todays Date" }'
+          - code: routing_code_value_is_too_short
+            category: routing_code_value
+            message: routing_code_value can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1, "indices" => ["0", "1"] }'
+          - code: routing_code_value_is_too_long
+            category: routing_code_value
+            message: routing_code_value can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50, "indices" => ["0", "1"] }'
+          - code: routing_code_value_type_is_wrong
+            category: routing_code_value
+            message: routing_code_value should be of hash type
+            params: '{ "type" => "hash" }'
+          - code: bic_swift_is_in_invalid_format
+            category: bic_swift
+            message: bic_swift is in invalid format
+            params: ''
+          - code: iban_is_too_long
+            category: iban
+            message: iban can not be longer than 34 character(s)
+            params: '{ "maxlength" => 34 }'
+          - code: iban_is_too_short
+            category: iban
+            message: iban can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: iban_is_in_invalid_format
+            category: iban
+            message: iban is in invalid format
+            params: ''
+          - code: default_beneficiary_type_is_wrong
+            category: default_beneficiary
+            message: default_beneficiary should be of boolean type
+            params: '{ "type" => "boolean" }'
+          - code: name_is_too_short
+            category: name
+            message: name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: name_is_too_long
+            category: name
+            message: name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: order_asc_desc_not_in_range
+            category: order_asc_desc
+            message: 'order_asc_desc should be in range: asc, desc'
+            params: '{ "range" => "asc, desc" }'
+          - code: order_not_in_range
+            category: order
+            message: 'order should be in range: bank_account_holder_name, beneficiary_country, currency, account_number, bic_swift,
+              iban, default_beneficiary, bank_address, name, bank_account_type, beneficiary_entity_type, beneficiary_city,
+              beneficiary_address, beneficiary_company_name, beneficiary_first_name, beneficiary_last_name, beneficiary_state_or_province,
+              beneficiary_postcode, created_at, updated_at'
+            params: '{ "range" => "bank_account_holder_name, beneficiary_country, currency, account_number, bic_swift, iban,
+              default_beneficiary, bank_address, name, bank_account_type, beneficiary_entity_type, beneficiary_city, beneficiary_address,
+              beneficiary_company_name, beneficiary_first_name, beneficiary_last_name, beneficiary_state_or_province, beneficiary_postcode,
+              created_at, updated_at" }'
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_is_not_valid_uuid
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: beneficiary_external_reference_is_too_short
+            category: beneficiary_external_reference
+            message: beneficiary_external_reference can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_external_reference_is_too_long
+            category: beneficiary_external_reference
+            message: beneficiary_external_reference can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: cope_not_in_range
+            category: scope
+            message: 'scope should be in range: own, all, clients'
+            params: '{ "range" => "own, all, clients" }'
+          - code: beneficiary_entity_type_not_in_range
+            category: beneficiary_entity_type
+            message: 'beneficiary_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: beneficiary_company_name_is_too_short
+            category: beneficiary_company_name
+            message: beneficiary_company_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_company_name_is_too_long
+            category: beneficiary_company_name
+            message: beneficiary_company_name can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_first_name_is_too_short
+            category: beneficiary_first_name
+            message: beneficiary_first_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_first_name_is_too_long
+            category: beneficiary_first_name
+            message: beneficiary_first_name can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_last_name_is_too_short
+            category: beneficiary_last_name
+            message: beneficiary_last_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_last_name_is_too_long
+            category: beneficiary_last_name
+            message: beneficiary_last_name can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_city_is_too_short
+            category: beneficiary_city
+            message: beneficiary_city can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_city_is_too_long
+            category: beneficiary_city
+            message: beneficiary_city can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_postcode_is_too_short
+            category: beneficiary_postcode
+            message: beneficiary_postcode can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_postcode_is_too_long
+            category: beneficiary_postcode
+            message: beneficiary_postcode can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_state_or_province_is_too_short
+            category: beneficiary_state_or_province
+            message: beneficiary_state_or_province can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_state_or_province_is_too_long
+            category: beneficiary_state_or_province
+            message: beneficiary_state_or_province can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: page_type_is_wrong
+            category: page
+            message: page should be of integer type
+            params: '{ "type" => "integer" }'
+          - code: page_is_too_small
+            category: page
+            message: page can not be smaller than 1
+            params: '{ "minvalue" => 1 }'
+          - code: per_page_type_is_wrong
+            category: per_page
+            message: per_page should be of integer type
+            params: '{ "type" => "integer" }'
+          - code: per_page_is_too_small
+            category: per_page
+            message: per_page can not be smaller than 1
+            params: '{ "minvalue" => 1 }'
+          - code: order_asc_desc_not_in_range
+            category: order_asc_desc
+            message: 'order_asc_desc should be in range: asc, desc'
+            params: '{ "range" => "asc, desc" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindBeneficiariesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /beneficiaries/{id}:
+    get:
+      tags:
+      - Beneficiaries
+      summary: Get Beneficiary
+      description: Gets a beneficiary with the given ID.
+      operationId: GetBeneficiary
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Beneficiary UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Beneficiary'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: beneficiary_not_found
+            category: id
+            message: Beneficiary was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetBeneficiaryError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+    post:
+      tags:
+      - Beneficiaries
+      summary: Update Beneficiary
+      description: Updates an existing beneficiary. Returns the updated beneficiary entity on success. <br> Please note that
+        it's not possible to change a beneficiary's entity type (company or individual) by an update. To achieve this, you
+        should create a new beneficiary.
+      operationId: UpdateBeneficiary
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Beneficiary UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: A nickname for the beneficiary.
+                  pattern: \S+
+                  minLength: 1
+                  maxLength: 100
+                bank_account_holder_name:
+                  type: string
+                  description: Bank account holder's name.
+                  minLength: 1
+                  maxLength: 255
+                bank_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Country in which the beneficiary's bank account is held. Two-letter ISO country code.
+                  pattern: ^[A-Z]{2}$
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which money is held in the beneficiary's bank account. Three-letter ISO currency
+                    code.
+                  pattern: ^[A-Z]{3}$
+                email:
+                  type: string
+                  description: Beneficiary's email address.
+                  pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
+                  minLength: 6
+                  maxLength: 255
+                beneficiary_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code. If the beneficiary is a company, this is the country in which
+                    the company is registered. If the beneficiary is an individual, this is the country in which the beneficiary
+                    is based.
+                  pattern: ^[A-Z]{2}$
+                account_number:
+                  type: string
+                  description: Bank account number.
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_1:
+                  type: string
+                  description: Local payment routing system.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value_1:
+                  type: string
+                  description: Routing code for "routing_code_type_1".
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_2:
+                  type: string
+                  description: Local payment routing system.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value_2:
+                  type: string
+                  description: Routing code for "routing_code_type_2".
+                  minLength: 1
+                  maxLength: 50
+                payment_types[]:
+                  type: array
+                  description: Currencycloud supports two types of payment - "priority" (Swift) made using the Swift network,
+                    and "regular" (local) made using the local bank network.
+                  default:
+                  - regular
+                  items:
+                    type: string
+                    enum:
+                    - priority
+                    - regular
+                bic_swift:
+                  type: string
+                  description: BIC/Swift code
+                  pattern: ^(\w{8}|\w{11})$
+                iban:
+                  type: string
+                  description: IBAN code
+                  pattern: ([A-Z0-9]\s*){15,34}
+                default_beneficiary:
+                  type: boolean
+                  description: Payments are made automatically to default beneficiaries when a beneficiary is not specified.
+                  default: false
+                bank_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 100
+                bank_name:
+                  type: string
+                  description: Bank name
+                  minLength: 1
+                bank_account_type:
+                  type: string
+                  description: Bank account type.
+                  enum:
+                  - checking
+                  - savings
+                beneficiary_entity_type:
+                  type: string
+                  description: Legal entity
+                  enum:
+                  - company
+                  - individual
+                beneficiary_company_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "company". Company names cannot consist entirely of
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_first_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual". Individual names cannot contain any
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_last_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual". Individual names cannot contain any
+                    numbers or company signifiers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_city:
+                  type: string
+                  description: City name, should not consist of only numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_postcode:
+                  type: string
+                  description: Postal code
+                  maxLength: 12
+                beneficiary_state_or_province:
+                  type: string
+                  format: date
+                  description: State or province.
+                beneficiary_date_of_birth:
+                  type: string
+                  format: date
+                  description: If "beneficiary_entity_type" is "company", date of registration.<br> If "beneficiary_entity_type"
+                    is "individual", date of birth. The date of birth for the individual should not exceed 125 years and cannot
+                    be a date in the future.<br> ISO 8601 format YYYY-MM-DD.
+                beneficiary_identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the beneficiary. Required documentation will
+                    vary depending on the country in which the beneficiary's bank account is held.
+                  enum:
+                  - citizenship_papers
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - incorporation_number
+                  - matricula_consular
+                  - national_id
+                  - none
+                  - others
+                  - passport
+                  - registro_federal_de_contribuyentes
+                  - social_insurance_number
+                  - social_security_number
+                  - visa
+                beneficiary_identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  minLength: 1
+                  maxLength: 255
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: Contact UUID.
+                beneficiary_external_reference:
+                  type: string
+                  description: Beneficiary external reference.
+                  minLength: 1
+                  maxLength: 255
+                business_nature:
+                  type: string
+                  description: Beneficiary nature of business.
+                  maxLength: 255
+                company_website:
+                  type: string
+                  description: Beneficiary company website.
+                  maxLength: 255
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Beneficiary'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: beneficiary_not_found
+            category: id
+            message: Beneficiary was not found for this id
+            params: ''
+          - code: bank_account_holder_name_is_too_short
+            category: bank_account_holder_name
+            message: bank_account_holder_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_account_holder_name_is_too_long
+            category: bank_account_holder_name
+            message: bank_account_holder_name can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: email_is_too_long
+            category: email
+            message: email can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_address_is_too_short
+            category: beneficiary_address
+            message: beneficiary_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_address_is_too_long
+            category: beneficiary_address
+            message: beneficiary_address can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: account_number_is_too_short
+            category: account_number
+            message: account_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: account_number_is_too_long
+            category: account_number
+            message: account_number can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: account_number_is_missing
+            category: account_number
+            message: Account number is missing
+            params: ''
+          - code: account_number_is_invalid
+            category: account_number
+            message: Account number is in invalid format
+            params: ''
+          - code: routing_code_value_1_is_too_short
+            category: routing_code_value_1
+            message: routing_code_value_1 can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: routing_code_value_1_is_too_long
+            category: routing_code_value_1
+            message: routing_code_value_1 can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: routing_code_value_2_is_too_short
+            category: routing_code_value_2
+            message: routing_code_value_2 can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: routing_code_value_2_is_too_long
+            category: routing_code_value_2
+            message: routing_code_value_2 can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: iban_is_too_short
+            category: iban
+            message: iban can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: iban_is_too_long
+            category: iban
+            message: iban can not be longer than 34 character(s)
+            params: '{ "maxlength" => 34 }'
+          - code: iban_is_missing
+            category: iban
+            message: IBAN is missing
+            params: ''
+          - code: iban_is_invalid
+            category: iban
+            message: IBAN is in invalid format
+            params: ''
+          - code: bic_swift_is_missing
+            category: bic_swift
+            message: BIC/Swift is missing
+            params: ''
+          - code: bic_swift_is_invalid
+            category: bic_swift
+            message: BIC/Swift is in invalid format
+            params: ''
+          - code: bank_address_is_missing
+            category: bank_address
+            message: Bank address is missing
+            params: ''
+          - code: bank_address_is_too_short
+            category: bank_address
+            message: bank_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_address_is_too_long
+            category: bank_address
+            message: bank_address can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: bank_name_is_too_short
+            category: bank_name
+            message: bank_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_name_is_missing
+            category: bank_name
+            message: Bank name is missing
+            params: ''
+          - code: bank_account_type_not_in_range
+            category: bank_account_type
+            message: 'bank_account_type should be in range: checking, savings'
+            params: '{ "range" => "checking, savings" }'
+          - code: bank_account_type_is_missing
+            category: bank_account_type
+            message: Beneficiary bank account type is missing
+            params: ''
+          - code: name_is_in_invalid_format
+            category: name
+            message: name is in invalid format
+            params: ''
+          - code: name_is_too_short
+            category: name
+            message: name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: name_is_too_long
+            category: name
+            message: name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: default_beneficiary_type_is_wrong
+            category: default_beneficiary
+            message: default_beneficiary should be of boolean type
+            params: '{ "type" => "boolean" }'
+          - code: routing_code_type_1_not_in_range
+            category: routing_code_type_1
+            message: 'routing_code_type_1 should be in range: sort_code, bsb_code, institution_no, bank_code, branch_code,
+              aba, clabe, cnaps'
+            params: '{ "range" => "sort_code, bsb_code, institution_no, bank_code, branch_code, aba, clabe, cnaps" }'
+          - code: routing_code_type_2_not_in_range
+            category: routing_code_type_2
+            message: 'routing_code_type_2 should be in range: sort_code, bsb_code, institution_no, bank_code, branch_code,
+              aba, clabe, cnaps'
+            params: '{ "range => "sort_code, bsb_code, institution_no, bank_code, branch_code, aba, clabe, cnaps" }'
+          - code: beneficiary_country_is_in_invalid_format
+            category: beneficiary_country
+            message: beneficiary_country is in invalid format
+            params: ''
+          - code: beneficiary_entity_type_not_in_range
+            category: beneficiary_entity_type
+            message: 'beneficiary_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: beneficiary_entity_type_is_missing
+            category: beneficiary_entity_type
+            message: Beneficiary entity type is missing
+            params: ''
+          - code: beneficiary_company_name_is_missing
+            category: beneficiary_company_name
+            message: Beneficiary company name is missing
+            params: ''
+          - code: company_name_contains_numbers
+            category: beneficiary_company_name
+            message: Beneficiary names cannot consist entirely of numbers for a company
+            params: ''
+          - code: beneficiary_first_name_is_missing
+            category: beneficiary_first_name
+            message: Beneficiary first name is missing
+            params: ''
+          - code: beneficiary_last_name_is_missing
+            category: beneficiary_last_name
+            message: Beneficiary last name is missing
+            params: ''
+          - code: first_name_contains_numbers
+            category: beneficiary_first_name
+            message: Beneficiary names cannot contain numbers for an individual
+            params: ''
+          - code: last_name_contains_numbers
+            category: beneficiary_last_name
+            message: Beneficiary names cannot contain numbers for an individual
+            params: ''
+          - code: beneficiary_city_is_too_short
+            category: beneficiary_city
+            message: beneficiary_city can not be shorter than 1 character(s)
+            params: ''
+          - code: beneficiary_state_or_province_is_missing
+            category: beneficiary_state_or_province
+            message: Beneficiary state or province is missing
+            params: ''
+          - code: beneficiary_state_or_province_is_not_supported
+            category: beneficiary_state_or_province
+            message: Beneficiary state or province is not supported
+            params: ''
+          - code: beneficiary_state_or_province_is_too_short
+            category: beneficiary_state_or_province
+            message: beneficiary_state_or_province can not be shorter than 1 character(s)
+            params: ''
+          - code: beneficiary_postcode_is_missing
+            category: beneficiary_postcode
+            message: Beneficiary postcode is missing
+            params: ''
+          - code: beneficiary_date_of_birth_type_is_wrong
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: beneficiary_date_of_birth_is_earlier
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be later
+            params: ''
+          - code: beneficiary_date_of_birth_is_after
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be earlier
+            params: ''
+          - code: identification_type_is_invalid
+            category: beneficiary_identification_type
+            message: identification_type is invalid
+            params: ''
+          - code: identification_value_is_missing
+            category: beneficiary_identification_value
+            message: identification_value is missing
+            params: ''
+          - code: identification_value_is_invalid
+            category: beneficiary_identification_value
+            message: identification_value is invalid
+            params: ''
+          - code: bank_country_is_in_invalid_format
+            category: bank_country
+            message: bank_country is in invalid format
+            params: ''
+          - code: bank_country_is_not_supported
+            category: bank_country
+            message: bank_country is not supported
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is in invalid format
+            params: ''
+          - code: currency_code_is_invalid
+            category: currency
+            message: You can not use this currency with beneficiaries
+            params: ''
+          - code: unique_value_parameters
+            category: base
+            message: 'Following parameters should not have same values: routing_code_type_1, routing_code_type_2'
+            params: '{ "parameters" => "routing_code_type_1, routing_code_type_2" }'
+          - code: at_least_one_parameter
+            category: base
+            message: 'At least one parameter should be present: bank_account_holder_name, beneficiary_country, bank_country,
+              currency, email, beneficiary_address, account_number, routing_code_type_1, routing_code_type_2, routing_code_value_1,
+              routing_code_value_2, bic_swift, iban, default_beneficiary, bank_address, bank_name, name'
+            params: '{ "parameters" => "bank_account_holder_name, beneficiary_country, bank_country, currency, email, beneficiary_address,
+              account_number, routing_code_type_1, routing_code_type_2, routing_code_value_1, routing_code_value_2, bic_swift,
+              iban, default_beneficiary, bank_address, bank_name, name" }'
+          - code: payment_types_not_included_in_list
+            category: payment_types
+            message: One or more payment_types items are not included in list
+            params: '{ "list":"priority, regular" }'
+          - code: sort_code_is_missing
+            category: routing_code
+            message: Sort code is missing
+            params: ''
+          - code: sort_code_is_invalid
+            category: routing_code
+            message: Sort code is in invalid format
+            params: ''
+          - code: aba_is_missing
+            category: routing_code
+            message: ABA is missing
+            params: ''
+          - code: aba_is_invalid
+            category: routing_code
+            message: ABA is in invalid format
+            params: ''
+          - code: bsb_code_is_missing
+            category: routing_code
+            message: BSB code is missing
+            params: ''
+          - code: bsb_code_is_invalid
+            category: routing_code
+            message: BSB code is in invalid format
+            params: ''
+          - code: branch_code_is_missing
+            category: routing_code
+            message: Branch code is missing
+            params: ''
+          - code: branch_code_is_invalid
+            category: routing_code
+            message: Branch code is in invalid format
+            params: ''
+          - code: institution_no_is_missing
+            category: routing_code
+            message: Institution no is missing
+            params: ''
+          - code: institution_no_is_invalid
+            category: routing_code
+            message: Institution no is in invalid format
+            params: ''
+          - code: bank_code_is_missing
+            category: routing_code
+            message: Bank code is missing
+            params: ''
+          - code: bank_code_is_invalid
+            category: routing_code
+            message: Bank code is in invalid format
+            params: ''
+          - code: beneficiary_update_failed
+            category: beneficiary
+            message: Beneficiary was not updated
+            params: ''
+          - code: beneficiary_details_are_missing
+            category: beneficiary
+            message: 'Following beneficiary details are missing: beneficiary_company_name'
+            params: '{ "missing_details" => ["beneficiary_company_name"] }'
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: beneficiary_external_reference_is_too_long
+            category: beneficiary_external_reference
+            message: beneficiary_external_reference can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateBeneficiaryError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /beneficiaries/create:
+    post:
+      tags:
+      - Beneficiaries
+      summary: Create Beneficiary
+      description: Creates a new beneficiary. Returns the new beneficiary entity on success.
+      operationId: CreateBeneficiary
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: A nickname for the beneficiary.
+                  pattern: \S+
+                  minLength: 1
+                  maxLength: 100
+                bank_account_holder_name:
+                  type: string
+                  description: Bank account holder's name.
+                  minLength: 1
+                  maxLength: 255
+                bank_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter code for the country in which the beneficiary's bank account is held.
+                  pattern: ^[A-Z]{2}$
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which money is held in the beneficiary's bank account. Three-letter IDO currency
+                    code.
+                  pattern: ^[A-Z]{3}$
+                email:
+                  type: string
+                  description: Email address
+                  pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
+                  minLength: 6
+                  maxLength: 255
+                beneficiary_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code. If the beneficiary is a company, this is the country in which
+                    the company is registered. If the beneficiary is an individual, this is the country in which the beneficiary
+                    is based.
+                  pattern: ^[A-Z]{2}$
+                account_number:
+                  type: string
+                  description: Bank account number.
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_1:
+                  type: string
+                  description: Local payment routing system. If supplied, routing_code_value_1 should also be supplied.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value_1:
+                  type: string
+                  description: Routing code for routing_code_type_1. If supplied, routing_code_type_1 should also be supplied.
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_2:
+                  type: string
+                  description: Local payment routing system. If supplied, routing_code_value_2 should also be supplied.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value_2:
+                  type: string
+                  description: Routing code for routing_code_type_2. If supplied, routing_code_type_2 should also be supplied.
+                  minLength: 1
+                  maxLength: 50
+                bic_swift:
+                  type: string
+                  description: BIC/Swift code
+                  pattern: ^(\w{8}|\w{11})$
+                iban:
+                  type: string
+                  description: IBAN code
+                  pattern: ([A-Z0-9]\s*){15,34}
+                default_beneficiary:
+                  type: boolean
+                  description: Payments are made automatically to default beneficiaries when a beneficiary is not specified.
+                  default: false
+                bank_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 100
+                bank_name:
+                  type: string
+                  description: Bank name
+                  minLength: 1
+                bank_account_type:
+                  type: string
+                  description: Bank account type.
+                  enum:
+                  - checking
+                  - savings
+                beneficiary_entity_type:
+                  type: string
+                  description: Legal entity
+                  enum:
+                  - company
+                  - individual
+                beneficiary_company_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "company". Company names cannot consist entirely of
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_first_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual". Individual names cannot contain any
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_last_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual". Individual names cannot contain any
+                    numbers or company signifiers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_city:
+                  type: string
+                  description: City name, should not consists of only numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_postcode:
+                  type: string
+                  description: Postal code
+                  maxLength: 12
+                beneficiary_state_or_province:
+                  type: string
+                  description: State or province.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_date_of_birth:
+                  type: string
+                  format: date
+                  description: If "beneficiary_entity_type" is "company", date of registration.<br> If "beneficiary_entity_type"
+                    is "individual", date of birth. The date of birth for the individual should not exceed 125 years and cannot
+                    be a date in the future.<br> ISO 8601 format YYYY-MM-DD.
+                beneficiary_identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the beneficiary. Required documentation will
+                    vary depending on the country in which the beneficiar's bank account is held and on whether "beneficiary_entity_type"
+                    is "individual" or "company".
+                  enum:
+                  - citizenship_papers
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - incorporation_number
+                  - matricula_consular
+                  - national_id
+                  - none
+                  - others
+                  - passport
+                  - registro_federal_de_contribuyentes
+                  - social_insurance_number
+                  - social_security_number
+                  - visa
+                beneficiary_identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  minLength: 1
+                  maxLength: 255
+                payment_types[]:
+                  type: array
+                  description: 'Currencycloud supports two types of payments: "priority", made using the Swift network; and
+                    "regular", made using the local bank network.'
+                  default:
+                  - regular
+                  items:
+                    type: string
+                    enum:
+                    - priority
+                    - regular
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                beneficiary_external_reference:
+                  type: string
+                  description: Beneficiary external reference.
+                  minLength: 1
+                  maxLength: 255
+                business_nature:
+                  type: string
+                  description: Beneficiary nature of business.
+                  maxLength: 255
+                company_website:
+                  type: string
+                  description: Beneficiary company website.
+                  maxLength: 255
+              required:
+              - name
+              - bank_account_holder_name
+              - bank_country
+              - currency
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Beneficiary'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: bank_account_holder_name_is_required
+            category: bank_account_holder_name
+            message: bank_account_holder_name is required
+            params: ''
+          - code: bank_account_holder_name_is_too_short
+            category: bank_account_holder_name
+            message: bank_account_holder_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_account_holder_name_is_too_long
+            category: bank_account_holder_name
+            message: bank_account_holder_name can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: email_is_too_long
+            category: email
+            message: email can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: beneficiary_address_is_too_short
+            category: beneficiary_address
+            message: beneficiary_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_address_is_too_long
+            category: beneficiary_address
+            message: beneficiary_address can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: account_number_is_too_short
+            category: account_number
+            message: account_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: account_number_is_too_long
+            category: account_number
+            message: account_number can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: account_number_is_missing
+            category: account_number
+            message: Account number is missing
+            params: ''
+          - code: account_number_is_invalid
+            category: account_number
+            message: Account number is in invalid format
+            params: ''
+          - code: routing_code_value_1_is_too_short
+            category: routing_code_value_1
+            message: routing_code_value_1 can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: routing_code_value_1_is_too_long
+            category: routing_code_value_1
+            message: routing_code_value_1 can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: routing_code_value_2_is_too_short
+            category: routing_code_value_2
+            message: routing_code_value_2 can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: routing_code_value_2_is_too_long
+            category: routing_code_value_2
+            message: routing_code_value_2 can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: iban_is_too_short
+            category: iban
+            message: iban can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: iban_is_too_long
+            category: iban
+            message: iban can not be longer than 34 character(s)
+            params: '{ "maxlength" => 34 }'
+          - code: iban_is_missing
+            category: iban
+            message: IBAN is missing
+            params: ''
+          - code: iban_is_invalid
+            category: iban
+            message: IBAN is in invalid format
+            params: ''
+          - code: bic_swift_is_missing
+            category: bic_swift
+            message: BIC/Swift is missing
+            params: ''
+          - code: bic_swift_is_invalid
+            category: bic_swift
+            message: BIC/Swift is in invalid format
+            params: ''
+          - code: bank_address_is_missing
+            category: bank_address
+            message: Bank address is missing
+            params: ''
+          - code: bank_address_is_too_short
+            category: bank_address
+            message: bank_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_address_is_too_long
+            category: bank_address
+            message: bank_address can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: bank_name_is_too_short
+            category: bank_name
+            message: bank_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_name_is_missing
+            category: bank_name
+            message: Bank name is missing
+            params: ''
+          - code: bank_account_type_not_in_range
+            category: bank_account_type
+            message: 'bank_account_type should be in range: checking, savings'
+            params: '{ "range" => "checking, savings" }'
+          - code: bank_account_type_is_missing
+            category: bank_account_type
+            message: Beneficiary bank account type is missing
+            params: ''
+          - code: name_is_too_short
+            category: name
+            message: name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: name_is_in_invalid_format
+            category: name
+            message: name is in invalid format
+            params: ''
+          - code: name_is_too_long
+            category: name
+            message: name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100  }'
+          - code: default_beneficiary_type_is_wrong
+            category: default_beneficiary
+            message: default_beneficiary should be of boolean type
+            params: '{ "type" => "boolean"  }'
+          - code: routing_code_type_1_not_in_range
+            category: routing_code_type_1
+            message: 'routing_code_type_1 should be in range: sort_code, bsb_code, institution_no, bank_code, branch_code,
+              aba, clabe, cnaps'
+            params: '{ "range" => "sort_code, bsb_code, institution_no, bank_code, branch_code, aba, clabe, cnaps" }'
+          - code: routing_code_type_2_not_in_range
+            category: routing_code_type_2
+            message: 'routing_code_type_2 should be in range: sort_code, bsb_code, institution_no, bank_code, branch_code,
+              aba, clabe, cnaps'
+            params: '{ "range => "sort_code, bsb_code, institution_no, bank_code, branch_code, aba, clabe, cnaps" }'
+          - code: beneficiary_country_is_in_invalid_format
+            category: beneficiary_country
+            message: beneficiary_country is in invalid format
+            params: ''
+          - code: beneficiary_entity_type_not_in_range
+            category: beneficiary_entity_type
+            message: 'beneficiary_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: beneficiary_entity_type_is_missing
+            category: beneficiary_entity_type
+            message: Beneficiary entity type is missing
+            params: ''
+          - code: beneficiary_company_name_is_missing
+            category: beneficiary_company_name
+            message: Beneficiary company name is missing
+            params: ''
+          - code: company_name_contains_numbers
+            category: beneficiary_company_name
+            message: Beneficiary names cannot consist entirely of numbers for a company
+            params: ''
+          - code: beneficiary_first_name_is_missing
+            category: beneficiary_first_name
+            message: Beneficiary first name is missing
+            params: ''
+          - code: beneficiary_last_name_is_missing
+            category: beneficiary_last_name
+            message: Beneficiary last name is missing
+            params: ''
+          - code: first_name_contains_numbers
+            category: beneficiary_first_name
+            message: Beneficiary names cannot contain numbers for an individual
+            params: ''
+          - code: last_name_contains_numbers
+            category: beneficiary_last_name
+            message: Beneficiary names cannot contain numbers for an individual
+            params: ''
+          - code: beneficiary_city_is_too_short
+            category: beneficiary_city
+            message: beneficiary_city can not be shorter than 1 character(s)
+            params: '{"minlength" => 1}'
+          - code: beneficiary_state_or_province_is_too_short
+            category: beneficiary_state_or_province
+            message: beneficiary_state_or_province can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: beneficiary_state_or_province_is_missing
+            category: beneficiary_state_or_province
+            message: Beneficiary state or province is missing
+            params: ''
+          - code: beneficiary_state_or_province_is_not_supported
+            category: beneficiary_state_or_province
+            message: Beneficiary state or province is not supported
+            params: ''
+          - code: beneficiary_postcode_is_missing
+            category: beneficiary_postcode
+            message: Beneficiary postcode is missing
+            params: ''
+          - code: beneficiary_date_of_birth_type_is_wrong
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: beneficiary_date_of_birth_is_earlier
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be later
+            params: ''
+          - code: beneficiary_date_of_birth_is_after
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be earlier
+            params: ''
+          - code: identification_type_is_invalid
+            category: beneficiary_identification_type
+            message: identification_type is invalid
+            params: ''
+          - code: identification_value_is_missing
+            category: beneficiary_identification_value
+            message: identification_value is missing
+            params: ''
+          - code: identification_value_is_invalid
+            category: beneficiary_identification_value
+            message: identification_value is invalid
+            params: ''
+          - code: bank_country_is_required
+            category: bank_country
+            message: bank_country is required
+            params: ''
+          - code: bank_country_is_in_invalid_format
+            category: bank_country
+            message: bank_country is in invalid format
+            params: ''
+          - code: bank_country_is_not_supported
+            category: bank_country
+            message: bank_country is not supported
+            params: ''
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is in invalid format
+            params: ''
+          - code: currency_code_is_invalid
+            category: currency
+            message: You can not use this currency with beneficiaries
+            params: ''
+          - code: unique_value_parameters
+            category: base
+            message: 'Following parameters should not have same values: routing_code_type_1, routing_code_type_2'
+            params: '{ "parameters" => "routing_code_type_1, routing_code_type_2" }'
+          - code: unsupported_beneficiary_country_code
+            category: base
+            message: Beneficiary country is not supported
+            params: ''
+          - code: beneficiary_create_failed
+            category: beneficiary
+            message: Beneficiary was not created
+            params: ''
+          - code: beneficiary_details_are_missing
+            category: beneficiary
+            message: 'Following beneficiary details are missing: beneficiary_company_name'
+            params: '{ "missing_details" => ["beneficiary_company_name"] }'
+          - code: payment_types_not_in_range
+            category: payment_types
+            message: 'payment_types should be in range: priority, regular'
+            params: '{ "range" => "priority, regular" }'
+          - code: payment_type_is_not_supported
+            category: payment_types
+            message: Payment type is not supported for given parameters
+            params: ''
+          - code: sort_code_is_missing
+            category: routing_code
+            message: Sort code is missing
+            params: ''
+          - code: sort_code_is_invalid
+            category: routing_code
+            message: Sort code is in invalid format
+            params: ''
+          - code: aba_is_missing
+            category: routing_code
+            message: ABA is missing
+            params: ''
+          - code: aba_is_invalid
+            category: routing_code
+            message: ABA is in invalid format
+            params: ''
+          - code: bsb_code_is_missing
+            category: routing_code
+            message: BSB code is missing
+            params: ''
+          - code: bsb_code_is_invalid
+            category: routing_code
+            message: BSB code is in invalid format
+            params: ''
+          - code: branch_code_is_missing
+            category: routing_code
+            message: Branch code is missing
+            params: ''
+          - code: branch_code_is_invalid
+            category: routing_code
+            message: Branch code is in invalid format
+            params: ''
+          - code: institution_no_is_missing
+            category: routing_code
+            message: Institution no is missing
+            params: ''
+          - code: institution_no_is_invalid
+            category: routing_code
+            message: Institution no is in invalid format
+            params: ''
+          - code: bank_code_is_missing
+            category: routing_code
+            message: Bank code is missing
+            params: ''
+          - code: bank_code_is_invalid
+            category: routing_code
+            message: Bank code is in invalid format
+            params: ''
+          - code: cnaps_is_missing
+            category: routing_code
+            message: CNAPS number is missing
+            params: ''
+          - code: cnaps_is_invalid
+            category: routing_code
+            message: CNAPS number is in invalid format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: beneficiary_external_reference_is_too_long
+            category: beneficiary_external_reference
+            message: beneficiary_external_reference can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateBeneficiaryError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /beneficiaries/{id}/delete:
+    post:
+      tags:
+      - Beneficiaries
+      summary: Delete Beneficiary
+      description: Delete a beneficiary associated with a sub-account. If the deletion is successful, the beneficiary's final
+        state is returned.
+      operationId: DeleteBeneficiary
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Beneficiary UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Beneficiary'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: beneficiary_not_found
+            category: id
+            message: Beneficiary was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteBeneficiaryError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /beneficiaries/validate:
+    post:
+      tags:
+      - Beneficiaries
+      summary: Validate Beneficiary
+      description: Validates a new beneficiary's bank details, without actually creating a record of the beneficiary. On success,
+        returns an object that represents the entity that would be created if the beneficiary was saved.
+      operationId: ValidateBeneficiary
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                bank_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter code for the country in which the beneficiary's bank account is held.
+                  pattern: ^[A-Z]{2}$
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which money is held in the beneficiary's bank account. Three-digit currency code.
+                  pattern: ^[A-Z]{3}$
+                beneficiary_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code. If the beneficiary is a company, this is the country in which
+                    the company is registered. If the beneficiary is an individual, this is the country in which the beneficiary
+                    is based.
+                  pattern: ^[A-Z]{2}$
+                account_number:
+                  type: string
+                  description: Bank account number.
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_1:
+                  type: string
+                  description: Local payment routing system. If supplied, routing_code_value_1 should also be supplied.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value_1:
+                  type: string
+                  description: Routing code for routing_code_type_1. If supplied, routing_code_type_1 should also be supplied.
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_2:
+                  type: string
+                  description: Local payment routing system. If supplied, routing_code_value_2 should also be supplied.
+                  enum:
+                  - aba
+                  - bank_code
+                  - branch_code
+                  - bsb_code
+                  - clabe
+                  - cnaps
+                  - ifsc
+                  - institution_no
+                  - sort_code
+                routing_code_value_2:
+                  type: string
+                  description: Routing code for routing_code_type_2. If supplied, routing_code_type_2 should also be supplied.
+                  minLength: 1
+                  maxLength: 50
+                bic_swift:
+                  type: string
+                  description: BIC/Swift code
+                  pattern: ^(\w{8}|\w{11})$
+                iban:
+                  type: string
+                  description: IBAN code
+                  pattern: ([A-Z0-9]\s*){15,34}
+                bank_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 100
+                bank_name:
+                  type: string
+                  description: Bank name
+                  minLength: 1
+                bank_account_type:
+                  type: string
+                  description: Bank account type.
+                  enum:
+                  - checking
+                  - savings
+                beneficiary_entity_type:
+                  type: string
+                  description: Legal entity
+                  enum:
+                  - company
+                  - individual
+                beneficiary_company_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "company". Company names cannot consist entirely of
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_first_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual". Individual names cannot contain any
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_last_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual". Individual names cannot contain any
+                    numbers.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_city:
+                  type: string
+                  description: City
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_postcode:
+                  type: string
+                  description: Postal code
+                  maxLength: 12
+                beneficiary_state_or_province:
+                  type: string
+                  description: State or province.
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_date_of_birth:
+                  type: string
+                  format: date
+                  description: If "beneficiary_entity_type" is "company", date of registration. If "beneficiary_entity_type"
+                    is "individual", date of birth. ISO 8601 format YYYY-MM-DD.
+                beneficiary_identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the beneficiary. Required documentation will
+                    vary depending on the country in which the beneficiary's bank account is held.
+                  enum:
+                  - citizenship_papers
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - incorporation_number
+                  - matricula_consular
+                  - national_id
+                  - none
+                  - others
+                  - passport
+                  - registro_federal_de_contribuyentes
+                  - social_insurance_number
+                  - social_security_number
+                  - visa
+                beneficiary_identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  minLength: 1
+                  maxLength: 255
+                payment_types[]:
+                  type: array
+                  description: 'Currencycloud supports two types of payments: "priority", made using the Swift network; and
+                    "regular", made using the local bank network.'
+                  default:
+                  - regular
+                  items:
+                    type: string
+                    enum:
+                    - priority
+                    - regular
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+              required:
+              - bank_country
+              - currency
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Beneficiary'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: beneficiary_country_is_in_invalid_format
+            category: beneficiary_country
+            message: beneficiary_country is in invalid format
+            params: ''
+          - code: beneficiary_entity_type_not_in_range
+            category: beneficiary_entity_type
+            message: 'beneficiary_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: beneficiary_entity_type_is_missing
+            category: beneficiary_entity_type
+            message: Beneficiary entity type is missing
+            params: ''
+          - code: beneficiary_company_name_is_missing
+            category: beneficiary_company_name
+            message: Beneficiary company name is missing
+            params: ''
+          - code: company_name_contains_numbers
+            category: beneficiary_company_name
+            message: Beneficiary names cannot consist entirely of numbers for a company
+            params: ''
+          - code: beneficiary_first_name_is_missing
+            category: beneficiary_first_name
+            message: Beneficiary first name is missing
+            params: ''
+          - code: beneficiary_last_name_is_missing
+            category: beneficiary_last_name
+            message: Beneficiary last name is missing
+            params: ''
+          - code: first_name_contains_numbers
+            category: beneficiary_first_name
+            message: Beneficiary names cannot contain numbers for an individual
+            params: ''
+          - code: last_name_contains_numbers
+            category: beneficiary_last_name
+            message: Beneficiary names cannot contain numbers for an individual
+            params: ''
+          - code: beneficiary_state_or_province_is_missing
+            category: beneficiary_state_or_province
+            message: Beneficiary state or province is missing
+            params: ''
+          - code: beneficiary_state_or_province_is_not_supported
+            category: beneficiary_state_or_province
+            message: Beneficiary state or province is not supported
+            params: ''
+          - code: beneficiary_postcode_is_missing
+            category: beneficiary_postcode
+            message: Beneficiary postcode is missing
+            params: ''
+          - code: beneficiary_date_of_birth_type_is_wrong
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: beneficiary_date_of_birth_is_earlier
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be later
+            params: ''
+          - code: beneficiary_date_of_birth_is_after
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be earlier
+            params: ''
+          - code: account_number_is_too_short
+            category: account_number
+            message: account_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: account_number_is_too_long
+            category: account_number
+            message: account_number can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: account_number_is_missing
+            category: account_number
+            message: Account number is missing
+            params: ''
+          - code: account_number_is_invalid
+            category: account_number
+            message: Account number is in invalid format
+            params: ''
+          - code: routing_code_value_1_is_too_short
+            category: routing_code_value_1
+            message: routing_code_value_1 can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: routing_code_value_1_is_too_long
+            category: routing_code_value_1
+            message: routing_code_value_1 can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: routing_code_value_2_is_too_short
+            category: routing_code_value_2
+            message: routing_code_value_2 can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: routing_code_value_2_is_too_long
+            category: routing_code_value_2
+            message: routing_code_value_2 can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: iban_is_too_short
+            category: iban
+            message: iban can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: iban_is_too_long
+            category: iban
+            message: iban can not be longer than 34 character(s)
+            params: '{ "maxlength" => 34 }'
+          - code: iban_is_missing
+            category: iban
+            message: IBAN is missing
+            params: ''
+          - code: iban_is_invalid
+            category: iban
+            message: IBAN is in invalid format
+            params: ''
+          - code: bic_swift_is_missing
+            category: bic_swift
+            message: BIC/Swift is missing
+            params: ''
+          - code: bic_swift_is_invalid
+            category: bic_swift
+            message: BIC/Swift is in invalid format
+            params: ''
+          - code: bank_address_is_missing
+            category: bank_address
+            message: Bank address is missing
+            params: ''
+          - code: bank_address_is_too_short
+            category: bank_address
+            message: bank_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_address_is_too_long
+            category: bank_address
+            message: bank_address can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: bank_name_is_too_short
+            category: bank_name
+            message: bank_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: bank_name_is_missing
+            category: bank_name
+            message: Bank name is missing
+            params: ''
+          - code: bank_account_type_not_in_range
+            category: bank_account_type
+            message: 'bank_account_type should be in range: checking, savings'
+            params: '{ "range" => "checking, savings" }'
+          - code: bank_account_type_is_missing
+            category: bank_account_type
+            message: Beneficiary bank account type is missing
+            params: ''
+          - code: routing_code_type_1_not_in_range
+            category: routing_code_type_1
+            message: 'routing_code_type_1 should be in range: sort_code, bsb_code, institution_no, bank_code, branch_code,
+              aba, clabe, cnaps'
+            params: '{ "range" => "sort_code, bsb_code, institution_no, bank_code, branch_code, aba, clabe, cnaps" }'
+          - code: routing_code_type_2_not_in_range
+            category: routing_code_type_2
+            message: 'routing_code_type_2 should be in range: sort_code, bsb_code, institution_no, bank_code, branch_code,
+              aba, clabe, cnaps'
+            params: '{ "range => "sort_code, bsb_code, institution_no, bank_code, branch_code, aba, clabe, cnaps" }'
+          - code: bank_country_is_required
+            category: bank_country
+            message: bank_country is required
+            params: ''
+          - code: bank_country_is_in_invalid_format
+            category: bank_country
+            message: bank_country is in invalid format
+            params: ''
+          - code: bank_country_is_not_supported
+            category: bank_country
+            message: bank_country is not supported
+            params: ''
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is in invalid format
+            params: ''
+          - code: currency_code_is_invalid
+            category: currency
+            message: You can not use this currency with beneficiaries
+            params: ''
+          - code: unique_value_parameters
+            category: base
+            message: 'Following parameters should not have same values: routing_code_type_1, routing_code_type_2'
+            params: '{ "parameters" => "routing_code_type_1, routing_code_type_2" }'
+          - code: beneficiary_create_failed
+            category: beneficiary
+            message: Beneficiary was not created
+            params: ''
+          - code: beneficiary_details_are_missing
+            category: beneficiary
+            message: 'Following beneficiary details are missing: beneficiary_company_name'
+            params: '{ "missing_details" => ["beneficiary_company_name"] }'
+          - code: payment_types_not_in_range
+            category: payment_types
+            message: 'payment_types should be in range: priority, regular'
+            params: '{ "range" => "priority, regular" }'
+          - code: sort_code_is_missing
+            category: routing_code
+            message: Sort code is missing
+            params: ''
+          - code: sort_code_is_invalid
+            category: routing_code
+            message: Sort code is in invalid format
+            params: ''
+          - code: aba_is_missing
+            category: routing_code
+            message: ABA is missing
+            params: ''
+          - code: aba_is_invalid
+            category: routing_code
+            message: ABA is in invalid format
+            params: ''
+          - code: bsb_code_is_missing
+            category: routing_code
+            message: BSB code is missing
+            params: ''
+          - code: bsb_code_is_invalid
+            category: routing_code
+            message: BSB code is in invalid format
+            params: ''
+          - code: branch_code_is_missing
+            category: routing_code
+            message: Branch code is missing
+            params: ''
+          - code: branch_code_is_invalid
+            category: routing_code
+            message: Branch code is in invalid format
+            params: ''
+          - code: institution_no_is_missing
+            category: routing_code
+            message: Institution no is missing
+            params: ''
+          - code: institution_no_is_invalid
+            category: routing_code
+            message: Institution no is in invalid format
+            params: ''
+          - code: bank_code_is_missing
+            category: routing_code
+            message: Bank code is missing
+            params: ''
+          - code: bank_code_is_invalid
+            category: routing_code
+            message: Bank code is in invalid format
+            params: ''
+          - code: beneficiary_update_failed
+            category: beneficiary
+            message: Beneficiary was not updated
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidateBeneficiaryError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /beneficiaries/account_verification:
+    post:
+      tags:
+      - Beneficiaries
+      summary: Verify Beneficiary Account
+      description: This service is currently only available to in-scope clients who must provide Confirmation of Payee (CoP)
+        or Verification of Payee (VoP) services to their end-users making local GBP payments in the UK or SEPA EUR payments.<br><br>
+        CoP and VoP are both peer-to-peer name-checking service designed to help reduce misdirected payments and provide greater
+        assurance that payments are being sent, and collected from, the intended account holder for domestic payments. <br><br>
+        Currently, access is restricted to UK and EU institutions and in-scope clients.<br><br> We plan to add more market
+        coverage to this API in the future, thereby extending access to additional clients.<br><br> If you're interested in
+        learning more or have received notification that you're in-scope, please contact your Account Manager or our support
+        team.
+      operationId: BeneficiaryAccountVerification
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                payment_type:
+                  type: string
+                  description: 'Currencycloud supports two types of payments: ''priority'', made using the Swift network and
+                    ''regular'', made using the local bank network. Confirmation of Payee and Verification of Payee checks
+                    only apply to local transactions so this field should always be set to ''regular''.'
+                  enum:
+                  - regular
+                  - priority (not supported for this endpoint)
+                bank_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter code for the country in which the beneficiary's bank account is held.
+                  pattern: ^[A-Z]{2}$
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which money will be sent to the beneficiary's bank account. Three-character currency
+                    code. 'GBP' for Confirmation of Payee, 'EUR' for Verification of Payee.
+                  enum:
+                  - GBP
+                  - EUR
+                  default: GBP
+                  pattern: ^[A-Z]{3}$
+                account_number:
+                  type: string
+                  description: Bank account number. Required when currency is 'GBP' (Confirmation of Payee).
+                  minLength: 1
+                  maxLength: 50
+                beneficiary_entity_type:
+                  type: string
+                  description: Legal entity - 'individual' or 'company'.<br> - If 'individual' then 'beneficiary_first_name'
+                    and 'beneficiary_last_name' are required.<br> - If 'company' then 'beneficiary_company_name' is required.<br>
+                    - Required when currency is 'GBP' (Confirmation of Payee).<br> - Not required when currency is 'EUR' (Verification
+                    of Payee).
+                  enum:
+                  - company
+                  - individual
+                beneficiary_company_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "company".
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_first_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                beneficiary_last_name:
+                  type: string
+                  description: Required if "beneficiary_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                routing_code_type_1:
+                  type: string
+                  description: Local payment routing system. Defaults to 'sort_code'.
+                routing_code_value_1:
+                  type: string
+                  description: Routing system value i.e. the account's sort code. Required when currency is 'GBP' (Confirmation
+                    of Payee).
+                  minLength: 1
+                  maxLength: 50
+                routing_code_type_2:
+                  type: string
+                  description: Second local payment routing system. If supplied, routing_code_value_2 should also be supplied.
+                    Necessary for when more than one routing code is required.
+                routing_code_value_2:
+                  type: string
+                  description: Routing code for routing_code_type_2. If supplied, routing_code_type_2 should also be supplied.
+                  minLength: 1
+                  maxLength: 50
+                bic_swift:
+                  type: string
+                  description: BIC/Swift code
+                  pattern: ^(\w{8}|\w{11})$
+                iban:
+                  type: string
+                  description: IBAN code. Required when currency is 'EUR' (Verification of Payee). Must match <code>^[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{1,30}$</code>
+                  pattern: ([A-Z0-9]\s*){15,34}
+                secondary_reference_data:
+                  type: string
+                  description: For customer accounts that are not uniquely addressable by a sort code and account number,
+                    but instead rely on their PSP to credit their account via SRD – i.e. using the reference field in the
+                    payment with a further unique identifier.
+                  pattern: ^[a-zA-Z]{2}[0-9]{2}[a-zA-Z0-9]{1,30}$
+              required:
+              - currency
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BeneficiaryAccountVerificationResult'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_field_account_number
+            category: account_number
+            message: account_number must match \"^[0-9]{8}$\"
+            params: ''
+          - code: invalid_beneficiary_type
+            category: beneficiary_entity_type
+            message: Beneficiary_entity_type must be either 'individual' or 'company'.
+            params: '{ "range" => "individual, company" }'
+            enum: individual company
+          - code: invalid_field_routing_code_value_1
+            category: routing_code_value_1
+            message: routing_code_value_1 must match \"^[0-9]{6}$\"
+            params: ''
+          - code: invalid_field_company_name
+            category: beneficiary_company_name
+            message: beneficiary_company_name must match \"[a-zA-Z0-9-'\\s]+\"
+            params: ''
+          - code: missing_company_name
+            category: beneficiary_company_name
+            message: beneficiary_company_name size must be between 0 and 140
+            params: ''
+          - code: invalid_field_beneficiary_first_name
+            category: beneficiary_first_name
+            message: beneficiary_first_name must match \"[a-zA-Z0-9-'\\s]+\"
+            params: ''
+          - code: invalid_field_beneficiary_first_name
+            category: beneficiary_first_name
+            message: beneficiary_first_name size must be between 0 and 140
+            params: ''
+          - code: invalid_field_beneficiary_last_name
+            category: beneficiary_last_name
+            message: beneficiary_last_name must match \"[a-zA-Z0-9-'\\s]+\"
+            params: ''
+          - code: invalid_field_beneficiary_last_name
+            category: beneficiary_last_name
+            message: beneficiary_last_name size must be between 0 and 140
+            params: ''
+          - code: invalid_field_bank_country
+            category: bank_country
+            message: bank_country must match \”^[A-Z]{2}$
+            params: ''
+          - code: missing_individual_names
+            category: beneficiary_last_name
+            message: beneficiary_first_name and beneficiary_last_name are required when beneficiary_entity_type is individual.
+            params: ''
+          - code: missing_company_name
+            category: company_name
+            message: beneficiary_company_name is required when beneficiary_entity_type is company.
+            params: ''
+          - code: expect_individual_names_only
+            category: beneficiary_last_name
+            message: beneficiary_company_name must not be supplied when beneficiary_entity_type is individual.
+            params: ''
+          - code: expect_company_name_only
+            category: beneficiary_last_name
+            message: beneficiary_first_name and beneficiary_last_name must not be supplied when beneficiary_entity_type is
+              company.
+            params: ''
+          - code: invalid_bank_country
+            category: bank_country
+            message: Country ${bank_country} is not supported
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BeneficiaryAccountVerificationError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /contacts/current:
+    get:
+      tags:
+      - Contacts
+      summary: Get Authenticating Contact
+      description: Gets the contact record for the authenticated user.
+      operationId: GetAuthenticatingContact
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Contact'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /contacts/find:
+    post:
+      tags:
+      - Contacts
+      summary: Find Contacts
+      description: Returns contacts that match the parameters.
+      operationId: FindContactsPost
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_name:
+                  type: string
+                  description: Account name
+                  pattern: \S+
+                  minLength: 1
+                  maxLength: 150
+                account_id:
+                  type: string
+                  format: uuid
+                  description: Sub-Account UUID
+                first_name:
+                  type: string
+                  description: The contact's first name.
+                  minLength: 1
+                  maxLength: 100
+                last_name:
+                  type: string
+                  description: The contact's last name.
+                  minLength: 1
+                  maxLength: 100
+                email_address:
+                  type: string
+                  description: The contact's email address.
+                  pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
+                  minLength: 6
+                  maxLength: 255
+                your_reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                phone_number:
+                  type: string
+                  description: The contact's phone number.
+                  minLength: 1
+                  maxLength: 100
+                login_id:
+                  type: string
+                  description: The contact's Currencycloud login ID.
+                  minLength: 1
+                  maxLength: 50
+                status:
+                  type: string
+                  description: Contact status - "enabled" allows the contact to conduct activity on the sub-account, "not_enabled"
+                    disables the contact.
+                  enum:
+                  - enabled
+                  - not_enabled
+                locale:
+                  type: string
+                  description: Locale code ("en", "en-US", "fr-FR").
+                  minLength: 2
+                  maxLength: 5
+                timezone:
+                  type: string
+                  description: Timezone ("Europe/London", "America/New_York").
+                  minLength: 7
+                  maxLength: 35
+                page:
+                  type: string
+                  description: Page number
+                  pattern: ^\d+$
+                per_page:
+                  type: string
+                  description: Number of results per page.
+                  pattern: ^\d+$
+                order:
+                  type: string
+                  description: Any field name to change the sort order.
+                  minLength: 1
+                  maxLength: 255
+                order_asc_desc:
+                  type: string
+                  description: Sort records in ascending or descending order.
+                  enum:
+                  - asc
+                  - desc
+                  default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                properties:
+                  contacts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Contact'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindContactsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /contacts/{id}:
+    get:
+      tags:
+      - Contacts
+      summary: Get Contact
+      description: Gets the contact for the given ID.
+      operationId: GetContact
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Contact UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Contact'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: contact_not_found
+            category: id
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetContactError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          - code: first_name_invalid_format
+            category: first_name
+            message: Please make sure that first_name doesn't contain < or > symbols
+            params: ''
+          - code: last_name_invalid_format
+            category: last_name
+            message: Please make sure that last_name doesn't contain < or > symbols
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+    post:
+      tags:
+      - Contacts
+      summary: Update Contact
+      description: Updates an existing contact. Returns the updated contact entity on success.
+      operationId: UpdateContact
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Contact UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: first_name
+        in: query
+        description: The contact's first name.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 100
+      - name: last_name
+        in: query
+        description: The contact's last name.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 100
+      - name: email_address
+        in: query
+        description: The contact's email address. A request to update a contact's email address does not immediately update
+          the value. Instead, an email change request flow is initiated, sending notifications to both the old and new email
+          addresses. The value will be updated when the change is confirmed via a link sent to the new email address.
+        required: false
+        schema:
+          type: string
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
+          minLength: 6
+          maxLength: 255
+      - name: your_reference
+        in: query
+        description: User-generated reference code.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: phone_number
+        in: query
+        description: The contact's phone number.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 100
+      - name: mobile_phone_number
+        in: query
+        description: The contact's mobile phone number.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 100
+      - name: login_id
+        in: query
+        description: The contact's Currencycloud login ID.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 50
+      - name: status
+        in: query
+        description: Contact status - "enabled" allows the contact to conduct activity on the sub-account, "not_enabled" disables
+          the contact.
+        required: false
+        schema:
+          type: string
+          enum:
+          - enabled
+          - not_enabled
+      - name: locale
+        in: query
+        description: Locale code ("en", "en-US", "fr-FR").
+        required: false
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 5
+      - name: timezone
+        in: query
+        description: Timezone ("Europe/London", "America/New_York").
+        required: false
+        schema:
+          type: string
+          minLength: 7
+          maxLength: 35
+      - name: date_of_birth
+        in: query
+        description: Contact's date of birth. ISO 8601 format YYYY-MM-DD. Required if account type is individual.
+        required: false
+        schema:
+          type: string
+          format: date
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Contact'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: at_least_one_parameter
+            category: base
+            message: 'At least one parameter should be present: first_name, last_name, email_address, phone_number, mobile_phone_number,
+              login_id, locale, timezone, status'
+            params: ''
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: first_name_is_too_short
+            category: first_name
+            message: first_name cann ot be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: first_name_is_too_long
+            category: first_name
+            message: first_name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: last_name_is_too_short
+            category: last_name
+            message: last_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: last_name_is_too_long
+            category: last_name
+            message: last_name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: email_address_is_too_short
+            category: email_address
+            message: email_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: email_address_is_too_long
+            category: email_address
+            message: email_address can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: email_address_is_in_invalid_format
+            category: email_address
+            message: email_address is in invalid format
+            params: ''
+          - code: phone_number_is_too_short
+            category: phone_number
+            message: phone_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: phone_number_is_too_long
+            category: phone_number
+            message: phone_number can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: mobile_phone_number_is_too_short
+            category: mobile_phone_number
+            message: mobile_phone_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: mobile_phone_number_is_too_long
+            category: mobile_phone_number
+            message: mobile_phone_number can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: login_id_in_use
+            category: login_id
+            message: 'login_id already in use: john.smith@company.com'
+            params: ''
+          - code: login_id_is_too_long
+            category: login_id
+            message: login_id can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: locale_is_too_short
+            category: locale
+            message: locale can not be shorter than 2 character(s)
+            params: '{ "minlength" => 2 }'
+          - code: locale_is_too_long
+            category: locale
+            message: locale can not be longer than 5 character(s)
+            params: '{ "maxlength" => 5 }'
+          - code: timezone_is_too_short
+            category: timezone
+            message: timezone can not be shorter than 7 character(s)
+            params: '{ "minlength" => 7 }'
+          - code: timezone_is_too_long
+            category: timezone
+            message: timezone can not be longer than 35 character(s)
+            params: '{ "maxlength" => 35 }'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: enabled, not_enabled'
+            params: ''
+          - code: date_of_birth_type_is_wrong
+            category: date_of_birth
+            message: date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: date_of_birth_is_required
+            category: date_of_birth
+            message: Date of Birth is a required field. Please provide date of birth (YYYY-MM-DD)
+            params: ''
+          - code: contact_not_found
+            category: id
+            message: Contact was not found for this id
+            params: ''
+          - code: editing_first_last_name_not_allowed
+            category: name
+            message: You cannot edit First and Last name. Please contact support for additional information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateContactError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          - code: first_name_invalid_format
+            category: first_name
+            message: Please make sure that first_name doesn't contain < or > symbols
+            params: ''
+          - code: last_name_invalid_format
+            category: last_name
+            message: Please make sure that last_name doesn't contain < or > symbols
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /contacts/create:
+    post:
+      tags:
+      - Contacts
+      summary: Create Contact
+      description: Creates a new contact and attaches it to a sub-account. Returns the new contact entity on success.
+      operationId: CreateContact
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_id:
+                  type: string
+                  format: uuid
+                  description: Account UUID
+                first_name:
+                  type: string
+                  description: The contact's first name.
+                  minLength: 1
+                  maxLength: 100
+                last_name:
+                  type: string
+                  description: The contact's last name.
+                  minLength: 1
+                  maxLength: 100
+                email_address:
+                  type: string
+                  description: The contact's email address.
+                  pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
+                  minLength: 6
+                  maxLength: 255
+                phone_number:
+                  type: string
+                  description: The contact's phone number.
+                  minLength: 1
+                  maxLength: 100
+                your_reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                mobile_phone_number:
+                  type: string
+                  description: The contact's mobile phone number.
+                  minLength: 1
+                  maxLength: 100
+                login_id:
+                  type: string
+                  description: The contact's Currencycloud login ID, allows the contact to login and conduct activity on the
+                    sub-account.
+                  minLength: 1
+                  maxLength: 50
+                status:
+                  type: string
+                  description: Contact status - "enabled" allows the contact to conduct activity on the sub-account, "not_enabled"
+                    disables the contact.
+                  enum:
+                  - enabled
+                  - not_enabled
+                locale:
+                  type: string
+                  description: Locale code ("en", "en-US", "fr-FR").
+                  minLength: 2
+                  maxLength: 5
+                timezone:
+                  type: string
+                  description: Timezone ("Europe/London", "America/New_York").
+                  minLength: 7
+                  maxLength: 35
+                date_of_birth:
+                  type: string
+                  format: date
+                  description: The contact's date of birth. ISO 8601 format YYYY-MM-DD. <b>Required if account type is individual</b>.
+              required:
+              - account_id
+              - first_name
+              - last_name
+              - email_address
+              - phone_number
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Contact'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: first_name_invalid_format
+            category: first_name
+            message: Please make sure that first_name doesn't contain < or > symbols
+            params: ''
+          - code: last_name_invalid_format
+            category: last_name
+            message: Please make sure that last_name doesn't contain < or > symbols
+            params: ''
+          - code: account_id_is_required
+            category: account_id
+            message: account_id is required
+            params: ''
+          - code: first_name_is_required
+            category: first_name
+            message: first_name is required
+            params: ''
+          - code: last_name_is_required
+            category: last_name
+            message: last_name is required
+            params: ''
+          - code: email_address_is_required
+            category: email_address
+            message: email_address is required
+            params: ''
+          - code: phone_number_is_required
+            category: phone_number
+            message: phone_number is required
+            params: ''
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: ''
+          - code: first_name_is_too_short
+            category: first_name
+            message: first_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: first_name_is_too_long
+            category: first_name
+            message: first_name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: last_name_is_too_short
+            category: last_name
+            message: last_name can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: last_name_is_too_long
+            category: last_name
+            message: last_name can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: email_address_is_too_short
+            category: email_address
+            message: email_address can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: email_address_is_too_long
+            category: email_address
+            message: email_address can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: email_address_is_in_invalid_format
+            category: email_address
+            message: email_address is in invalid format
+            params: ''
+          - code: phone_number_is_too_short
+            category: phone_number
+            message: phone_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: phone_number_is_too_long
+            category: phone_number
+            message: phone_number can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: mobile_phone_number_is_too_short
+            category: mobile_phone_number
+            message: mobile_phone_number can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: mobile_phone_number_is_too_long
+            category: mobile_phone_number
+            message: mobile_phone_number can not be longer than 100 character(s)
+            params: '{ "maxlength" => 100 }'
+          - code: login_id_is_too_short
+            category: login_id
+            message: login_id can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: login_id_in_use
+            category: login_id
+            message: login_id already in use
+            params: '{"field": "login_id"}'
+          - code: login_id_is_too_long
+            category: login_id
+            message: login_id can not be longer than 50 character(s)
+            params: '{ "maxlength" => 50 }'
+          - code: locale_is_too_short
+            category: locale
+            message: locale can not be shorter than 2 character(s)
+            params: '{ "minlength" => 2 }'
+          - code: locale_is_too_long
+            category: locale
+            message: locale can not be longer than 5 character(s)
+            params: '{ "maxlength" => 5 }'
+          - code: timezone_is_too_short
+            category: timezone
+            message: timezone can not be shorter than 7 character(s)
+            params: '{ "minlength" => 7 }'
+          - code: timezone_is_too_long
+            category: timezone
+            message: timezone can not be longer than 35 character(s)
+            params: '{ "maxlength" => 35 }'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: enabled, not_enabled.'
+            params: ''
+          - code: date_of_birth_type_is_wrong
+            category: date_of_birth
+            message: date_of_birth should be of date type.
+            params: '{ "type" => "date" }'
+          - code: date_of_birth_is_required
+            category: date_of_birth
+            message: Date of Birth is a required field. Please provide date of birth (YYYY-MM-DD)
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateContactError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /contacts/generate_hmac_key:
+    post:
+      tags:
+      - Contacts
+      summary: Generate HMAC Key for Contact
+      description: Generates a new account HMAC key for the current contact.
+      operationId: GenerateHMACKey
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HMACKey'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: generate_hmac_key_wrong_brand
+            category: base
+            message: HMAC key can't be generated for that brand
+            params: ''
+          - code: generate_hmac_key_brand_not_configured
+            category: base
+            message: 'Brand #{brand} should be configured first'
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateHMACKeyError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: Permission denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/create:
+    post:
+      tags:
+      - Conversions
+      summary: Create Conversion
+      description: Creates a new conversion. Returns the details of the created conversion on success.
+      operationId: CreateConversion
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                buy_currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-character ISO code for currency purchased.
+                  pattern: ^[A-Z]{3}$
+                sell_currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-character ISO code for currency sold.
+                  pattern: ^[A-Z]{3}$
+                fixed_side:
+                  type: string
+                  description: Fix the buy or sell currency.
+                  enum:
+                  - buy
+                  - sell
+                amount:
+                  type: string
+                  description: Amount of the fixed buy or sell currency.
+                  pattern: ^\d+(\.\d{1,3})?$
+                term_agreement:
+                  type: boolean
+                  description: Indicates agreement to terms and conditions.
+                  enum:
+                  - true
+                  - false
+                conversion_date:
+                  type: string
+                  format: date
+                  description: Earliest delivery date in UTC time zone. Format YYYY-MM-DD.
+                client_buy_amount:
+                  type: string
+                  description: Client buy amount.
+                  pattern: ^\d+(\.\d{1,2})?$
+                client_sell_amount:
+                  type: string
+                  description: Client sell amount.
+                  pattern: ^\d+(\.\d{1,2})?$
+                reason:
+                  type: string
+                  description: User-generated reason for conversion - freeform text.
+                  minLength: 1
+                  maxLength: 255
+                unique_request_id:
+                  type: string
+                  description: User-generated idempotency key. Beneficial for request tracking / management.
+                  minLength: 1
+                  maxLength: 255
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                conversion_date_preference:
+                  type: string
+                  description: Available and required only if conversion_date is not provided.<br> Must be one of the following:<br>
+                    - 'earliest' for earliest available conversion date. Make sure there is sufficient time to send funds
+                    to Currencycloud.<br> - 'next_day' for next day available conversion date - T+1.<br> - 'default' for conversion
+                    - T+1 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC
+                    restricted currencies</a>, T+2 for all others.<br> - 'optimize_liquidity' for maximizing chances of getting
+                    a successful rate. Most relevant for exotic pairs. Conversion is T+0 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC
+                    restricted currencies</a>, and T+1 or T+2 for all others.
+                  enum:
+                  - default
+                  - earliest
+                  - next_day
+                  - optimize_liquidity
+              required:
+              - buy_currency
+              - sell_currency
+              - fixed_side
+              - amount
+              - term_agreement
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversion'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters
+            params: '{ "parameters" => { "extra_param" => "extra_value" } }'
+          - code: buy_currency_is_in_invalid_format
+            category: buy_currency
+            message: buy_currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: buy_currency_is_required
+            category: buy_currency
+            message: buy_currency is required
+            params: ''
+          - code: invalid_buy_currency
+            category: buy_currency
+            message: buy_currency is invalid
+            params: ''
+          - code: sell_currency_is_required
+            category: sell_currency
+            message: sell_currency is required
+            params: ''
+          - code: sell_currency_is_in_invalid_format
+            category: sell_currency
+            message: sell_currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: invalid_sell_currency
+            category: sell_currency
+            message: sell_currency is invalid
+            params: ''
+          - code: amount_is_required
+            category: amount
+            message: amount is required
+            params: ''
+          - code: conversion_above_limit
+            category: amount
+            message: Conversion of ${currency} equivalent ${amount} exceeds your limit of ${limit_amount}
+          - code: conversion_below_limit
+            category: amount
+            message: Conversion of ${currency} equivalent ${amount} is less than your lower limit of ${limit_amount}
+          - code: amount_type_is_wrong
+            category: amount
+            message: amount should be of numeric type
+            params: '{ "type" => "numeric" }'
+          - code: reason_is_required
+            category: reason
+            message: reason is required
+            params: ''
+          - code: reason_is_too_short
+            category: reason
+            message: reason can not be shorter than 1 character(s)
+            params: '{ "minlength" => 1 }'
+          - code: client_rate_is_in_invalid_format
+            category: client_rate
+            message: client_rate should be of numeric type with 4 dp
+            params: '{ "type" => "numeric_with_precision", "precision" => 4 }'
+          - code: invalid_client_rate
+            category: client_rate
+            message: client_rate is invalid
+            params: '{ "client_rate" => "1.455543..1.778997" }'
+          - code: currency_pair_not_available_for_weekend
+            category: currency_pair_not_available_for_weekend
+            message: Currency pair is not available for weekend
+            params: ''
+          - code: client_rate_is_required
+            category: client_rate
+            message: The client_rate is required if you supply currency_pair
+            params: ''
+          - code: fixed_side_is_required
+            category: fixed_side
+            message: fixed_side is required
+            params: ''
+          - code: fixed_side_not_in_range
+            category: fixed_side
+            message: 'fixed_side should be in range: buy, sell'
+            params: '{ "range" => "buy, sell" }'
+          - code: term_agreement_is_required
+            category: term_agreement
+            message: term_agreement is required
+            params: ''
+          - code: term_agreement_type_is_wrong
+            category: term_agreement
+            message: term_agreement should be of boolean type
+            params: '{ "type" => "boolean" }'
+          - code: conversion_create_failed
+            category: conversion_create_failed
+            message: Conversion create failed
+            params: ''
+          - code: currency_pair_is_in_invalid_format
+            category: currency_pair
+            message: currency_pair is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency_pair" }'
+          - code: invalid_currency_pair
+            category: invalid_currency_pair
+            message: The currency_pair should be the real market pair of the buy_currency and sell_currency
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_is_not_valid_uuid
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: on_behalf_of_is_required
+            category: on_behalf_of
+            message: You should do this conversion on behalf of someone if you supply client_rate
+            params: ''
+          - code: currency_pair_is_required
+            category: currency_pair_is_required
+            message: The currency_pair is required if you supply client_rate
+            params: ''
+          - code: variable_value_dates_not_permitted
+            category: variable_value_dates_not_permitted
+            message: Sorry - you are not currently setup to trade with variable value dates, please contact us on the phone
+              if you want to change this or wish to trade now on the phone.
+            params: ''
+          - code: client_buy_amount_is_in_invalid_format
+            category: client_buy_amount
+            message: client_buy_amount should be of numeric type with 2 dp
+            params: '{ "type" => "client_buy_amount" }'
+          - code: client_sell_amount_is_in_invalid_format
+            category: client_sell_amount
+            message: client_sell_amount should be of numeric type with 2 dp
+            params: '{ "type" => "client_sell_amount" }'
+          - code: cannot_fix_client_sell_on_fixed_sell_side
+            category: cannot_fix_client_sell_on_fixed_sell_side
+            message: You cannot specify a fixed client_sell_amount when the fixed side for a conversion is the sell side
+            params: '{ "type" => "client_sell_amount" }'
+          - code: client_buy_amount_exceeds_partner_buy_amount
+            category: client_buy_amount_exceeds_partner_buy_amount
+            message: The client buy amount specified is greater than the amount that you would be buying and is thus invalid
+            params: '{ "type" => "client_buy_amount" }'
+          - code: partner_sell_amount_exceeds_client_sell_amount
+            category: partner_sell_amount_exceeds_client_sell_amount
+            message: The client sell amount specified is less than the amount that you would be selling and is thus invalid
+            params: '{ "type" => "client_sell_amount" }'
+          - code: missing_partner_spread_table_data
+            category: missing_partner_spread_table_data
+            message: Sorry, the online partner pricing for the amount of the currency pair you are trying to trade has not
+              been set up
+            params: ''
+          - code: missing_client_spread_table_data
+            category: missing_client_spread_table_data
+            message: Sorry, the online client pricing for the amount of the currency pair you are trying to trade has not
+              been set up
+            params: ''
+          - code: fixed_amounts_not_permitted_for_this_user
+            category: fixed_amounts_not_permitted_for_this_user
+            message: You are not permitted to specify a fixed client_buy_amount or client_sell_amount for this customer
+            params: ''
+          - code: invalid_client_rate_combination
+            category: invalid_client_rate_combination
+            message: You cannot specify a client rate and client currency pair alongside a client buy amount or client sell
+              amount
+            params: ''
+          - code: duplicate_request
+            category: duplicate_request
+            message: The unique_request_id provided for this conversion has already been used, please provide a new unique_request_id
+              to successfully submit this conversion
+            params: ''
+          - code: invalid_conversion_date_combination
+            category: base
+            message: conversion_date_preference can not be specified along side a date parameter
+            params: ''
+          - code: invalid_conversion_date_preference
+            category: base
+            message: not a valid conversion date preference, possible options are earliest, optimize_liquidity, default, next_day
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}:
+    get:
+      tags:
+      - Conversions
+      summary: Get Conversion
+      description: Gets a conversion record for the provided unique ID.
+      operationId: GetConversion
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Conversion UUID, this is returned by a successful trade request when creating a conversion.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Conversion'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/find:
+    get:
+      tags:
+      - Conversions
+      summary: Find Conversions
+      description: Finds conversions based on search parameters. If no search parameters are provided, all conversions under
+        the house account are returned.
+      operationId: FindConversions
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: short_reference
+        in: query
+        description: Short reference code.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 25
+      - name: status
+        in: query
+        description: Conversion status.
+        required: false
+        schema:
+          type: string
+          enum:
+          - awaiting_funds
+          - closed
+          - funds_arrived
+          - funds_sent
+          - trade_settled
+      - name: buy_currency
+        in: query
+        description: The currency purchased- three character ISO code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: sell_currency
+        in: query
+        description: The currency sold - three character ISO code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: conversion_ids[]
+        in: query
+        description: One or more conversion UUIDs to filter out of results.
+        required: false
+        schema:
+          type: array
+          format: uuid
+          items:
+            type: string
+      - name: created_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: created_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: updated_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: updated_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: conversion_date_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: conversion_date_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: currency_pair
+        in: query
+        description: Concatenated string of the two currencies traded, e.g. "USDEUR".
+        required: false
+        schema:
+          type: string
+          pattern: ^[A-Z]{6}$
+      - name: partner_buy_amount_from
+        in: query
+        description: Minimum buy amount (sub-accounts).
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: partner_buy_amount_to
+        in: query
+        description: Maximum buy amount (sub-accounts).
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: partner_sell_amount_from
+        in: query
+        description: Minimum sell amount (sub-accounts).
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: partner_sell_amount_to
+        in: query
+        description: Maximum sell amount (sub-accounts).
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: buy_amount_from
+        in: query
+        description: Minimum buy amount.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: buy_amount_to
+        in: query
+        description: Maximum buy amount.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: sell_amount_from
+        in: query
+        description: Minimum sell amount.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: sell_amount_to
+        in: query
+        description: Maximum sell amount.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: scope
+        in: query
+        description: '"Own" account, "clients" sub-accounts, or "all" accounts.'
+        required: false
+        schema:
+          type: string
+          enum:
+          - all
+          - clients
+          - own
+          default: own
+      - name: settlement_date_from
+        in: query
+        description: Earliest date when sold currency debited. Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: settlement_date_to
+        in: query
+        description: Latest date when sold currency debited. Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: unique_request_id
+        in: query
+        description: User-generated idempotency key.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: page
+        in: query
+        description: Page number.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: Any field name to change the sort order.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Conversion'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindConversionsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/cancellation_quote:
+    get:
+      tags:
+      - Conversions
+      summary: Quote Conversion Cancellation
+      description: Gets a quote of the projected cost to cancel a conversion identified by a provided unique ID {id}.
+      operationId: ConversionCancellationQuote
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Conversion UUID, this is returned by a successful trade request when creating a conversion.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionCancellationQuote'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/cancel:
+    post:
+      tags:
+      - Conversions
+      summary: Cancel a Conversion
+      description: Cancels the conversion identified by the provided unique ID {id}.
+      operationId: CancelConversion
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: UUID of the conversion that is being cancelled. The UUID is returned by a successful trade request when
+          creating a conversion.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                notes:
+                  type: string
+                  description: Notes describing the reason for cancellation.
+                  minLength: 1
+                  maxLength: 255
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionProfitAndLoss'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/date_change_quote:
+    get:
+      tags:
+      - Conversions
+      summary: Quote Conversion Date Change
+      description: Gets a quote of the projected cost to change the date of a conversion identified by a provided unique ID
+        {id}.
+      operationId: ConversionDateChangeQuote
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Conversion UUID, this is returned by a successful trade request when creating a conversion.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: new_settlement_date
+        in: query
+        description: Desired new settlement date of conversion, format YYYY-MM-DD.
+        required: true
+        schema:
+          type: string
+          format: date
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionDateChange'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contacts
+            params: ''
+          - code: contact_not_found
+            category: contact_id
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/date_change:
+    post:
+      tags:
+      - Conversions
+      summary: Conversion Date Change
+      description: Changes the date of the conversion identified by the provided unique ID {id}.
+      operationId: ConversionDateChange
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: The UUID of the conversion that is being changed.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                new_settlement_date:
+                  type: string
+                  format: date
+                  description: New conversion settlement date, format YYYY-MM-DD.
+              required:
+              - new_settlement_date
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionDateChange'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: new_settlement_date_invalid_in_past
+            category: new_settlement_date
+            message: New settlement date has to be today or greater than today's date
+            params: ''
+          - code: new_settlement_date_invalid
+            category: new_settlement_date
+            message: Invalid new settlement date, next valid date time is - YYYY-MM-DDT15:30:00Z
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/profit_and_loss:
+    get:
+      tags:
+      - Conversions
+      summary: Retrieve Profit / Loss
+      description: Returns the information of any actions related to a conversion that have generated profit or loss, including
+        the profit or loss amount.
+      operationId: ConversionProfitAndLoss
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: account_id
+        in: query
+        description: UUID of the Account that the Conversion belongs to.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: contact_id
+        in: query
+        description: UUID of the Contact that performed the action.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: conversion_id
+        in: query
+        description: UUID of the conversion.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: event_type
+        in: query
+        description: Event type, in this case 'self_service_cancellation'.
+        required: false
+        schema:
+          type: string
+      - name: event_date_time_from
+        in: query
+        description: Allows you to return profit and losses that will be made from on or after a defined date/time. ISO 8601
+          standard.
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: event_date_time_to
+        in: query
+        description: Allows you to return profit and losses that will be made from on or before a defined date/time. ISO 8601
+          standard.
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: amount_from
+        in: query
+        description: Allows you to return profit and losses based on a minimum profit or loss amount.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_to
+        in: query
+        description: Allows you to return profit and losses based on a maximum profit or loss amount.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: currency
+        in: query
+        description: The currency of the profit and loss. ISO 4217 standard.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: scope
+        in: query
+        description: Scope allows contacts to search all profit and losses at all account levels. Defaults to own.<br> 'own'
+          - search profit and losses on the main account <br> 'clients' - search profit and losses of account sub-accounts
+          <br> 'all' - search profit and losses of main account and sub-accounts.
+        required: false
+        schema:
+          type: string
+          enum:
+          - all
+          - client
+          - own
+      - name: page
+        in: query
+        description: Returns a specific page within the results of a search.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Maximum number of entries to return per page of results.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: The field to order entries by.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Whether the order is ascending (asc) or descending (desc).
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversion_profit_and_losses:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConversionProfitAndLoss'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/split_preview:
+    get:
+      tags:
+      - Conversions
+      summary: Split Preview
+      description: Gets a preview of the details of each part of a split conversion specified by the provided unique conversion
+        ID {id}.
+      operationId: GetConversionSplitPreview
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: The UUID of the conversion to be split, the UUID is returned by a successful trade request when creating
+          a conversion.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: amount
+        in: query
+        description: The amount at which to split this conversion.
+        required: true
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionSplit'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: amount_is_required
+            category: amount
+            message: amount is required
+            params: ''
+          - code: amount_type_is_wrong
+            category: amount
+            message: amount should be of numeric type
+            params: ''
+          - code: amount_is_too_small
+            category: amount
+            message: amount can not be smaller than 1
+            params: ''
+          - code: parent_market_buy_amount_less_than_1
+            category: buy_amount
+            message: Remaining parent market buy amount cannot be less than 1
+            params: ''
+          - code: child_market_buy_amount_less_than_1
+            category: buy_amount
+            message: Remaining child market buy amount cannot be less than 1.
+            params: ''
+          - code: parent_market_sell_amount_less_than_1
+            category: sell_amount
+            message: Remaining parent market sell amount cannot be less than 1
+            params: ''
+          - code: child_market_sell_amount_less_than_1
+            category: sell_amount
+            message: Remaining child market sell amount cannot be less than 1.
+            params: ''
+          - code: split_amount_below_deposit_amount
+            category: amount
+            message: Remaining amount cannot be less than the original trade's deposit.
+            params: ''
+          - code: split_amount_exceeds_unallocated_funds
+            category: amount
+            message: Trade split amount cannot exceed unallocated funds if multiple payments attached.
+            params: ''
+          - code: conversion_status_is_incorrect
+            category: status
+            message: Trade must still be awaiting funds
+            params: ''
+          - code: split_amount_precision
+            category: amount
+            message: Amount precision is too low for currency GBP
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: You do not have permission 'split_conversion' to perform this operation
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: conversion_not_found
+            category: id
+            message: Conversion was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/split:
+    post:
+      tags:
+      - Conversions
+      summary: Conversion Split
+      description: Splits the conversion specified by the unique ID {id}. Upon success, it returns the details of the parent
+        and new child conversions.
+      operationId: SplitConversion
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: UUID of the conversion that is being split. The conversion UUID is returned by a successful trade request
+          when creating a conversion."
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                amount:
+                  type: string
+                  description: The amount at which to split this conversion.
+                  pattern: ^\d+(\.\d{1,3})?$
+              required:
+              - amount
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionSplit'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: You do not have permission 'split_conversion' to perform this operation
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /conversions/{id}/split_history:
+    get:
+      tags:
+      - Conversions
+      summary: Conversion Split History
+      description: Returns the history of executed conversion splits, specified by a unique conversion ID {id}.
+      operationId: GetConversionSplitHistory
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Conversion UUID - the UUID is returned by a successful trade request when creating a conversion.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionSplitHistory'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: invalid_extra_parameters
+            category: on_behalf_of
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: You do not have permission 'split_conversion' to perform this operation
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: conversion_not_found
+            message: Conversion was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /funding_accounts/find:
+    get:
+      tags:
+      - Funding
+      summary: Find Funding Accounts
+      description: Gets details of the Standard Settlement Instructions (SSIs) that can be used to settle and collect funds
+        in each available currency.
+      operationId: FindFundingAccounts
+      x-api-group: collect
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: payment_type
+        in: query
+        description: The type of SSI to be returned, priority (Swift) or regular (local). A null value returns all payment
+          types.
+        required: false
+        schema:
+          type: string
+          enum:
+          - priority
+          - regular
+      - name: currency
+        in: query
+        description: The currency of the account details required, ISO 4217 standard.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: account_id
+        in: query
+        description: UUID of a specific sub-account you want to see the SSIs for.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: Any field name to change the sort order.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  funding_accounts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FundingAccount'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: payment_type_not_in_range
+            category: payment_type
+            message: 'payment_type should be in range: priority, regular'
+            params: '{ "range" => "priority, regular" }'
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: currency_is_not_supported
+            category: currency
+            message: currency is not supported
+            params: ''
+          - code: funding_accounts_not_found
+            category: funding_accounts
+            message: No funding accounts found for this account
+            params: ''
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: on_behalf_of_is_not_valid_uuid
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindFundingAccountsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: account_not_found
+            category: account
+            message: Account was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: contact
+            message: Contact was not found for this id
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /funding_transactions/{id}:
+    get:
+      tags:
+      - Funding
+      summary: Get Funding Transaction
+      description: '
+
+        Gets the details of an approved funding transaction with the given ID.'
+      operationId: GetFundingTransaction
+      x-api-group: collect
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: The Related Entity UUID (related_entity_id) for the transaction.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FundingTransaction'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: contact
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetFundingTransactionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Transaction not found.
+          x-errors:
+          - code: transaction_not_found
+            category: id
+            message: Transaction not found
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/create:
+    post:
+      tags:
+      - Payments
+      summary: Create Payment
+      description: Submits a payment. On success, returns the new payment record. Use the <a href="/api-reference/#get-payer-requirements">Get
+        Payer Requirements</a> endpoint to find out what payer information needs to be provided.<br><br> Clients who are implementing
+        Strong Customer Authentication (SCA) for payments should refer to our <a href="../guides/integration-guides/sca_sponsored_api_payments">integration
+        guide</a>.
+      operationId: CreatePayment
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: x-sca-id
+        in: header
+        description: UUID to correlate to the SCA request generated when Validate Payment was called.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: x-sca-token
+        in: header
+        description: The OTP received following the Validate Payment request when SCA was required.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d{6}$
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which payment is made. Three-letter ISO currency code.
+                  pattern: ^[A-Z]{3}$
+                beneficiary_id:
+                  type: string
+                  format: uuid
+                  description: Beneficiary UUID
+                amount:
+                  type: string
+                  description: Amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                reason:
+                  type: string
+                  description: User-generated reason for payment - freeform text.
+                  minLength: 1
+                  maxLength: 255
+                reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                unique_request_id:
+                  type: string
+                  description: User-generated idempotency key.
+                  minLength: 1
+                  maxLength: 255
+                payment_date:
+                  type: string
+                  format: date
+                  description: Instructed date of payment - on this date we will attempt to debit funds on the account and
+                    submit the payment to the scheme. If the payment cannot be submitted before the cut-off (i.e. due to lack
+                    of funding), we will re-attempt on the next working day. Defaults to the earliest possible date if not
+                    passed as parameter. Any valid ISO 8601 format, e.g. "2023-12-31.
+                payment_type:
+                  type: string
+                  description: 'Currencycloud supports two types of payments: "priority", made using the Swift network; and
+                    "regular", made using the local bank network.'
+                  enum:
+                  - priority
+                  - regular
+                conversion_id:
+                  type: string
+                  format: uuid
+                  description: Conversion UUID
+                payer_entity_type:
+                  type: string
+                  description: Legal entity
+                  enum:
+                  - company
+                  - individual
+                payer_company_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "company".
+                  minLength: 1
+                  maxLength: 255
+                payer_first_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                payer_last_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "individual". Cannot contain any numbers or company signifiers.
+                  minLength: 1
+                  maxLength: 255
+                payer_city:
+                  type: string
+                  description: City name, should not consist of only numbers.
+                  minLength: 1
+                  maxLength: 255
+                payer_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 255
+                payer_postcode:
+                  type: string
+                  description: Postal code
+                  minLength: 1
+                  maxLength: 255
+                payer_state_or_province:
+                  type: string
+                  description: State or province.
+                  minLength: 1
+                  maxLength: 255
+                payer_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code.
+                  pattern: ^[A-Z]{2}$
+                payer_date_of_birth:
+                  type: string
+                  format: date
+                  description: If "payer_entity_type" is "company", this is the company registration date. If "payer_entity_type"
+                    is "individual", this is date of birth. ISO 8601 format YYYY-MM-DD.
+                payer_identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the payer. Required documentation will vary
+                    depending on the nationality or registered address of the payer.
+                  enum:
+                  - citizenship_papers
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - incorporation_number
+                  - matricula_consular
+                  - national_id
+                  - none
+                  - others
+                  - passport
+                  - registro_federal_de_contribuyentes
+                  - social_insurance_number
+                  - social_security_number
+                  - visa
+                payer_identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  minLength: 1
+                  maxLength: 255
+                ultimate_beneficiary_name:
+                  type: string
+                  description: The name of the ultimate beneficiary if different.
+                  minLength: 1
+                  maxLength: 255
+                purpose_code:
+                  type: string
+                  description: <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430000-Payment-Purpose-Codes">Payment
+                    Purpose Code</a> (Mandatory for all local INR and MYR payments, Swift CNY payments, and Swift payments
+                    in any currency to banks in Bahrain or the United Arab Emirates).
+                  minLength: 1
+                  maxLength: 255
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of. Payer details parameters should
+                    not be sent if using on_behalf_of, they will be populated using the details from the sub-account.
+                charge_type:
+                  type: string
+                  description: Payment Charges Setting value (only applicable to Swift payments). If this is left empty, the
+                    account's default value is used. Do not specify for regular (local) payments.
+                  enum:
+                  - ours
+                  - shared
+                fee_amount:
+                  type: string
+                  description: Fee amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                fee_currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency fee is paid in.
+                  pattern: ^[A-Z]{3}$
+                invoice_number:
+                  type: string
+                  description: The invoice number related to the payment. Necessary when making business-related INR payments,
+                    check our <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430000-Payment-Purpose-Codes">support
+                    article</a> to see if this applies to your purpose code. Can be up to 30 characters. Mandatory if supplying
+                    `invoice_date`.<br> For NOK payments, this field can optionally be used to provide the KID (Kundle ID).
+                    If supplied, the KID should be 2-25 digits.
+                  pattern: ^[a-zA-Z0-9]{1,30}$
+                invoice_date:
+                  type: string
+                  format: date
+                  description: The date of the invoice related to the payment. Necessary when making business-related INR
+                    payments, check our <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430000-Payment-Purpose-Codes">support
+                    article</a> to see if this applies to your purpose code. ISO 8601 format YYYY-MM-DD. Mandatory if supplying
+                    `invoice_number`.
+                payer_ultimate_account_number:
+                  type: string
+                  description: The payer's payment account number.
+                  maxLength: 35
+              required:
+              - currency
+              - beneficiary_id
+              - amount
+              - reason
+              - reference
+              - unique_request_id
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_type
+            category: type
+            message: Invalid Payment type
+            params: ''
+          - code: currency_length_is_invalid
+            category: currency
+            message: currency should be 3 character(s) long
+            params: ''
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: invalid_currency
+            category: currency
+            message: You cannot make payments with this currency
+            params: ''
+          - code: beneficiary_id_is_not_valid_uuid
+            category: beneficiary_id
+            message: beneficiary_id should be in UUID format
+            params: ''
+          - code: beneficiary_id_is_required
+            category: beneficiary_id
+            message: beneficiary_id is required
+            params: ''
+          - code: beneficiary_date_of_birth_type_is_wrong
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: beneficiary_date_of_birth_is_incorrect
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth is incorrect
+            params: ''
+          - code: beneficiary_date_of_birth_is_earlier
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be later
+            params: ''
+          - code: beneficiary_date_of_birth_is_after
+            category: beneficiary_date_of_birth
+            message: beneficiary_date_of_birth should be earlier
+            params: ''
+          - code: invalid_beneficiary_id
+            category: beneficiary_id
+            message: Unknown beneficiary_id
+            params: ''
+          - code: payment_above_limit
+            category: amount
+            message: ${amount} ${currency} exceeds the maximum amount of ${limit} ${currency} for a local payment
+            params: ''
+          - code: payer_entity_type_not_in_range
+            category: payer_entity_type
+            message: 'payer_entity_type should be in range: individual, company'
+            params: ''
+          - code: payer_details_are_missing
+            category: payer_entity_type
+            message: 'Following payer details are missing: payer_entity_type, payer_company_name, payer_first_name, payer_last_name,
+              payer_city, payer_address, payer_state_or_province, payer_postcode, payer_country, payer_date_of_birth, payer_identification_type,
+              payer_identification_value, payer_ultimate_account_number'
+            params: '{"missing_details" => "payer_entity_type, payer_company_name, payer_first_name, payer_last_name, payer_city,
+              payer_address, payer_state_or_province, payer_postcode, payer_country, payer_date_of_birth, payer_identification_type,
+              payer_identification_value, payer_ultimate_account_number"}'
+          - code: payer_entity_type_is_missing
+            category: payer_entity_type
+            message: Payer entity type is missing
+            params: ''
+          - code: payer_company_name_is_missing
+            category: payer_company_name
+            message: Payer company name is missing
+            params: ''
+          - code: payer_first_name_is_missing
+            category: payer_first_name
+            message: Payer first name is missing
+            params: ''
+          - code: payer_last_name_is_missing
+            category: payer_last_name
+            message: Payer last name is missing
+            params: ''
+          - code: payer_city_is_missing
+            category: payer_city
+            message: Payer city is missing
+            params: ''
+          - code: unsupported_payer_country_code
+            category: payer_country_code
+            message: Payer country is not supported
+            params: ''
+          - code: payer_state_or_province_is_missing
+            category: payer_state_or_province
+            message: Payer state or province is missing
+            params: ''
+          - code: payer_postcode_is_missing
+            category: payer_postcode
+            message: Payer postcode is missing
+            params: ''
+          - code: payer_date_of_birth_type_is_wrong
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: payer_date_of_birth_is_incorrect
+            category: payer_date_of_birth
+            message: payer_date_of_birth is incorrect
+            params: ''
+          - code: payer_date_of_birth_is_earlier
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be later
+            params: ''
+          - code: payer_date_of_birth_is_after
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be earlier
+            params: ''
+          - code: identification_type_is_missing
+            category: payer_identification_type
+            message: identification_type is missing
+            params: ''
+          - code: identification_type_is_invalid
+            category: payer_identification_type
+            message: identification_type is invalid
+            params: ''
+          - code: identification_value_is_missing
+            category: payer_identification_value
+            message: identification_value is missing
+            params: ''
+          - code: identification_value_is_invalid
+            category: payer_identification_value
+            message: identification_value is invalid
+            params: ''
+          - code: invalid_conversion_id
+            category: conversion_id
+            message: Conversion could not be found
+            params: ''
+          - code: conversion_is_already_settled
+            category: conversion_id
+            message: The conversion is already settled
+            params: ''
+          - code: invalid_payment_date
+            category: payment_date
+            message: The payment date is invalid
+            params: ''
+          - code: payment_date_is_too_early
+            category: payment_date
+            message: The payment date cannot be sooner than the conversion date
+            params: ''
+          - code: reference_is_too_long
+            category: reference
+            message: reference can not be longer than 255 character(s)
+            params: ''
+          - code: charge_type_not_available
+            category: charge_type
+            message: Not available charge_type has been provided
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: invalid_charge_type
+            category: charge_type
+            message: Invalid banking_charges supplied, must be in range [ours, shared]
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_charge_type_not_available
+            category: on_behalf_of
+            message: Not available charge_type has been provided for on_behalf_of
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: duplicate_request
+            category: duplicate_request
+            message: The unique_request_id provided for this payment has already been used, please provide a new unique_request_id
+              to successfully submit this payment
+            params: ''
+          - code: fee_amount_type_is_wrong
+            category: fee_amount
+            message: fee_amount should be of numeric type
+            params: '{ "type" => "numeric" }'
+          - code: fee_currency_is_in_invalid_format
+            category: fee_currency
+            message: fee_currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: unsupported_beneficiary_country_code
+            category: beneficiary_country_code
+            message: Beneficiary country is not supported
+            params: ''
+          - code: unsupported_account
+            category: account
+            message: The account is currently not permitted to create payments.
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: invalid_fee_amount_format
+            category: fee_amount
+            message: ${FEE_CURRENCY} only supports up to ${CURRENCY_NUMBER_OF_DECIMAL_PLACES} decimal places
+            params: ''
+          - code: payer_details_not_allowed
+            category: payer_details
+            message: This account is not allowed to pass payer details
+            params: ''
+          - code: unique_request_id_is_required
+            category: unique_request_id_is_required
+            message: unique_request_id is required
+            params: ''
+          - code: invoice_number_parameter_invalid
+            category: invoice_number
+            message: Invoice number can only contain alphanumeric characters and must be 30 characters or less
+          - code: invoice_number_missing
+            category: invoice_number
+            message: Invoice number is missing for provided invoice date $invoiceDate
+          - code: invalid_invoice_date
+            category: invoice_date
+            message: Invoice date must follow YYYY-MM-DD format
+          - code: invoice_date_missing
+            category: invoice_date
+            message: Invoice date is missing for provided invoice number $invoiceNumber
+          - code: incorrect_purpose_code
+            category: purpose_code
+            message: Purpose code is invalid
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatePaymentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/find:
+    get:
+      tags:
+      - Payments
+      summary: Find Payments
+      description: Searches for payment records.
+      operationId: FindPayments
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: short_reference
+        in: query
+        description: Short reference code.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 25
+      - name: currency
+        in: query
+        description: Currency in which payment was made. Three-letter ISO currency code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: amount
+        in: query
+        description: Exact amount
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_from
+        in: query
+        description: Minimum amount
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_to
+        in: query
+        description: Maximum amount
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: status
+        in: query
+        description: Payment status
+        required: false
+        schema:
+          type: string
+          enum:
+          - awaiting_authorisation
+          - authorised
+          - completed
+          - deleted
+          - failed
+          - new
+          - ready_to_send
+          - released
+          - submitted
+          - suspended
+      - name: reason
+        in: query
+        description: User-generated reason for payment. Freeform text.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: payment_date_from
+        in: query
+        description: Earliest instructed payment date. Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: payment_date_to
+        in: query
+        description: Latest instructed payment date. Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: transferred_at_from
+        in: query
+        description: Earliest date of payment processing. Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: transferred_at_to
+        in: query
+        description: Latest date of payment processing. Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: created_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: created_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: updated_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: updated_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59+00:00".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: beneficiary_id
+        in: query
+        description: Beneficiary UUID
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: conversion_id
+        in: query
+        description: Conversion UUID
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: with_deleted
+        in: query
+        description: Include deleted payments.
+        required: false
+        schema:
+          type: boolean
+          default: false
+      - name: payment_group_id
+        in: query
+        description: Payment group.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: unique_request_id
+        in: query
+        description: User-generated idempotency key.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: scope
+        in: query
+        description: '"Own" account, "clients" sub-accounts, or "all" accounts.'
+        required: false
+        schema:
+          type: string
+          enum:
+          - all
+          - clients
+          - own
+          default: own
+      - name: bulk_upload_id
+        in: query
+        description: Bulk upload reference code.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: Any field name to change the sort order.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      - name: charge_type
+        in: query
+        description: Payment Charges Setting value (only applicable to Swift payments). Limits the search results to payments
+          of the specified <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430820-Selecting-payment-charges-for-SWIFT-payments-FAQ">charge
+          type</a>.
+        required: false
+        schema:
+          type: string
+          enum:
+          - ours
+          - shared
+      - name: review_status
+        in: query
+        description: Compliance review status.
+        required: false
+        schema:
+          type: string
+          enum:
+          - in_review
+          - passed
+          - rejected
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payments:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Payment'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_currency
+            category: id
+            message: currency has invalid format
+            params: ''
+          - code: charge_type_not_available
+            category: charge_type
+            message: Not available charge_type has been provided
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: invalid_charge_type
+            category: charge_type
+            message: Invalid banking_charges supplied, must be in range [ours, shared]
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_charge_type_not_available
+            category: on_behalf_of
+            message: Not available charge_type has been provided for on_behalf_of
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: new, ready_to_send, completed, failed, released, suspended, awaiting_authorisation,
+              submitted, authorised, deleted"'
+            params: '{ "range" => "new, ready_to_send, completed, failed, released, suspended, awaiting_authorisation, submitted,
+              authorised, deleted" }'
+          - code: review_status_not_in_range
+            category: review_status
+            message: 'review_status should be in range: passed, in_review, rejected'
+            params: '{ "range" => "passed, in_review, rejected" }'
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindPaymentsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/{id}:
+    get:
+      tags:
+      - Payments
+      summary: Get Payment
+      description: Gets a payment record.
+      operationId: GetPayment
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: with_deleted
+        in: query
+        description: Include deleted payments.
+        required: false
+        schema:
+          type: boolean
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: review_status
+        in: query
+        description: Compliance review status.
+        required: false
+        schema:
+          type: string
+          enum:
+          - in_review
+          - passed
+          - rejected
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_id
+            category: id
+            message: ID has invalid format
+            params: ''
+          - code: with_deleted_type_is_wrong
+            category: id
+            message: with_deleted should be of boolean type
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: on_behalf_of_is_not_valid_UUID
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: review_status_not_in_range
+            category: review_status
+            message: 'review_status should be in range: passed, in_review, rejected'
+            params: '{ "range" => "passed, in_review, rejected"}'
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: payment_not_found
+            category: id
+            message: Payment was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+    post:
+      tags:
+      - Payments
+      summary: Update Payment
+      description: Updates a payment. On success, returns the updated payment entity.
+      operationId: UpdatePayment
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which the payment is being made. Three-letter ISO currency code.
+                  pattern: ^[A-Z]{3}$
+                beneficiary_id:
+                  type: string
+                  format: uuid
+                  description: Beneficiary UUID
+                amount:
+                  type: string
+                  description: Payment amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                payment_date:
+                  type: string
+                  format: date
+                  description: Instructed date of payment. Any valid ISO 8601 format, e.g. "2023-12-31".
+                reason:
+                  type: string
+                  description: User-generated reason for payment - freeform text.
+                  minLength: 1
+                  maxLength: 255
+                payment_type:
+                  type: string
+                  description: 'Currencycloud supports two types of payments: "priority", made using the Swift network; and
+                    "regular", made using the local bank network.'
+                  enum:
+                  - priority
+                  - regular
+                reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                conversion_id:
+                  type: string
+                  format: uuid
+                  description: Conversion UUID
+                payer_entity_type:
+                  type: string
+                  description: Legal entity
+                  enum:
+                  - company
+                  - individual
+                payer_company_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "company".
+                  minLength: 1
+                  maxLength: 255
+                payer_first_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                payer_last_name:
+                  type: string
+                  description: Required if payer_entity_type is "individual".
+                  minLength: 1
+                  maxLength: 255
+                payer_city:
+                  type: string
+                  description: City
+                  minLength: 1
+                  maxLength: 255
+                payer_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 255
+                payer_postcode:
+                  type: string
+                  description: Postal code
+                  minLength: 1
+                  maxLength: 255
+                payer_state_or_province:
+                  type: string
+                  description: State or province.
+                  minLength: 1
+                  maxLength: 255
+                payer_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code.
+                  pattern: ^[A-Z]{2}$
+                payer_date_of_birth:
+                  type: string
+                  format: date
+                  description: If the "payer_entity_type" is "company", this is the company registration date. If the "payer_entity_type"
+                    is "individual", this is the payer's date of birth. ISO 8601 format YYYY-MM-DD.
+                payer_identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the payer. Required documentation will vary
+                    depending on the nationality or registered address of the payer.
+                  enum:
+                  - citizenship_papers
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - incorporation_number
+                  - matricula_consular
+                  - national_id
+                  - none
+                  - others
+                  - passport
+                  - registro_federal_de_contribuyentes
+                  - social_insurance_number
+                  - social_security_number
+                  - visa
+                payer_identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  minLength: 1
+                  maxLength: 255
+                ultimate_beneficiary_name:
+                  type: string
+                  description: The name of the ultimate beneficiary if different.
+                  minLength: 1
+                  maxLength: 255
+                purpose_code:
+                  type: string
+                  description: Payment Purpose Code (Mandatory for all INR payments). See our <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430000-Payment-Purpose-Codes">support
+                    article</a> for more information.
+                  minLength: 1
+                  maxLength: 255
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                charge_type:
+                  type: string
+                  description: Payment Charges Setting value (only applicable to Swift payments). If empty, the account's
+                    default value is used. Do not specify for regular (local) payments.
+                  enum:
+                  - ours
+                  - shared
+                fee_amount:
+                  type: string
+                  description: Fee amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                fee_currency:
+                  type: string
+                  format: iso-4217
+                  description: The currency the fee is paid in.
+                  pattern: ^[A-Z]{3}$
+                invoice_number:
+                  type: string
+                  description: The invoice number related to the payment. Necessary when making business-related INR payments,
+                    check our <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430000-Payment-Purpose-Codes">support
+                    article</a> to see if this applies to your purpose code. Can be up to 30 characters. Mandatory if `invoice_date`
+                    is supplied.<br> For NOK payments, this field can optionally be used to provide the KID (Kundle ID). If
+                    supplied, the KID should be 2-25 digits.
+                  pattern: ^[a-zA-Z0-9]{1,30}$
+                invoice_date:
+                  type: string
+                  format: date
+                  description: The date of the invoice related to the payment. Necessary when making business-related INR
+                    payments, check our <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430000-Payment-Purpose-Codes">support
+                    article</a> to see if this applies to your purpose code. ISO 8601 format YYYY-MM-DD. Mandatory if `invoice_number`
+                    is supplied.
+                payer_ultimate_account_number:
+                  type: string
+                  description: The payer's payment account number.
+                  maxLength: 35
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error
+          x-errors:
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code
+            params: ''
+          - code: invalid_currency
+            category: currency
+            message: You cannot make payments with this currency
+            params: ''
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: beneficiary_id_is_not_valid_uuid
+            category: beneficiary_id
+            message: beneficiary_id should be in UUID format
+            params: ''
+          - code: invalid_beneficiary_id
+            category: beneficiary_id
+            message: Unknown beneficiary_id
+            params: ''
+          - code: invalid_beneficiary_currency
+            category: beneficiary_currency
+            message: You cannot assign this Beneficiary to the Payment as it is the incorrect currency
+            params: ''
+          - code: amount_type_is_wrong
+            category: amount
+            message: amount should be of numeric type
+            params: '{ "type" => "numeric" }'
+          - code: payment_above_limit
+            category: amount
+            message: 3000.00 EUR exceeds the maximum amount of 2500.00 EUR for a local payment.
+            params: '{ "amount" => 3000.0, "ccy" => "EUR", "limit" => 2500.0 }'
+          - code: invalid_amount_for_order
+            category: amount_for_order
+            message: The payment amount is more than the value of the order
+            params: ''
+          - code: payment_type_not_in_range
+            category: payment_type
+            message: 'payment_type should be in range: priority, regular'
+            params: ''
+          - code: invalid_conversion_id
+            category: conversion_id
+            message: Conversion could not be found.
+            params: ''
+          - code: conversion_id_is_not_valid_uuid
+            category: conversion_id
+            message: conversion_id should be in UUID format
+            params: ''
+          - code: invalid_payment_date
+            category: payment_date
+            message: The payment date is invalid
+            params: ''
+          - code: payment_date_type_is_wrong
+            category: payment_date
+            message: payment_date should be of date type
+            params: ''
+          - code: payment_date_is_too_early
+            category: payment_date
+            message: The payment date cannot be sooner than the conversion date
+            params: ''
+          - code: reference_is_too_long
+            category: reference
+            message: reference can not be longer than 255 character(s)
+            params: '{ "maxlength" => 255 }'
+          - code: payment_can_not_be_edited
+            category: can_not_be_edited
+            message: Sorry this Payment has already been processed and you are unable to Edit it
+            params: ''
+          - code: extra_dependent_params
+            category: base
+            message: Parameters payer_entity_type, payer_company_name, payer_first_name, payer_last_name, payer_address, payer_country,
+              payer_postcode, payer_state_or_province, payer_date_of_birth, payer_identification_type, payer_identification_value
+              can't be provided in the same request with 'payer_details_source' with value 'account'
+            params: ''
+          - code: payer_entity_type_not_in_range
+            category: payer_entity_type
+            message: 'payer_entity_type should be in range: individual, company'
+            params: '{ "range" => "individual, company" }'
+          - code: payer_details_are_missing
+            category: payer_entity_type
+            message: 'Following payer details are missing: payer_entity_type, payer_company_name, payer_first_name, payer_last_name,
+              payer_city, payer_address, payer_state_or_province, payer_postcode, payer_country, payer_date_of_birth, payer_identification_type,
+              payer_identification_value, payer_ultimate_account_number'
+            params: '{"missing_details" => "payer_entity_type, payer_company_name, payer_first_name, payer_last_name, payer_city,
+              payer_address, payer_state_or_province, payer_postcode, payer_country, payer_date_of_birth, payer_identification_type,
+              payer_identification_value, payer_ultimate_account_number"}'
+          - code: payer_date_of_birth_type_is_wrong
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: payer_date_of_birth_is_incorrect
+            category: payer_date_of_birth
+            message: payer_date_of_birth is incorrect
+            params: ''
+          - code: payer_date_of_birth_is_earlier
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be later
+            params: ''
+          - code: payer_date_of_birth_is_after
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be earlier
+            params: ''
+          - code: payer_identification_type_not_in_range
+            category: payer_identification_type
+            message: 'payer_identification_type should be in range: none, drivers_license, social_security_number, green_card,
+              passport, visa, matricula_consular, registro_federal_de_contribuyentes, credential_de_elector, social_insurance_number,
+              citizenship_papers, drivers_license_canadian, existing_credit_card_details, employer_identification_number,
+              national_id, others, incorporation_number, clave_unica_de_registro_de_poblacion'
+            params: ''
+          - code: identification_type_is_invalid
+            category: payer_identification_type
+            message: identification_type is invalid
+            params: ''
+          - code: identification_value_is_missing
+            category: payer_identification_value
+            message: identification_value is missing
+            params: ''
+          - code: identification_value_is_invalid
+            category: payer_identification_value
+            message: identification_value is invalid
+            params: ''
+          - code: charge_type_not_available
+            category: charge_type
+            message: Not available charge_type has been provided
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: charge_type_not_in_range
+            category: charge_type
+            message: 'charge_type should be in range: ours, shared'
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: on_behalf_of_is_not_valid_UUID
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: on_behalf_of_charge_type_not_available
+            category: on_behalf_of
+            message: Not available charge_type has been provided for on_behalf_of
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: fee_amount_type_is_wrong
+            category: fee_amount
+            message: fee_amount should be of numeric type
+            params: '{ "type" => "numeric" }'
+          - code: fee_currency_is_in_invalid_format
+            category: fee_currency
+            message: fee_currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: invalid_fields_for_company
+            category: fee_amount
+            message: Please provide payer_company_name, but not payer_first_name and payer_last_name
+            params: ''
+          - code: invalid_fields_for_individual
+            category: fee_amount
+            message: Please provide payer_first_name and payer_last_name, but not payer_company_name
+            params: ''
+          - code: incorrect_purpose_code
+            category: purpose_code
+            message: Purpose code is invalid
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: invoice_number_parameter_invalid
+            category: invoice_number
+            message: Invoice number can only contain alphanumeric characters and must be 30 characters or less
+          - code: invoice_number_missing
+            category: invoice_number
+            message: Invoice number is missing for provided invoice date $invoiceDate
+          - code: invalid_invoice_date
+            category: invoice_date
+            message: Invoice date must follow YYYY-MM-DD format
+          - code: invoice_date_missing
+            category: invoice_date
+            message: Invoice date is missing for provided invoice number $invoiceNumber
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdatePaymentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: payment_not_found
+            category: id
+            message: Payment was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/{id}/confirmation:
+    get:
+      tags:
+      - Payments
+      summary: Get Payment Confirmation
+      description: Gets confirmation for a given payment.
+      operationId: GetPaymentConfirmation
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentConfirmation'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: payment_not_found
+            category: id
+            message: Payment was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentSubmissionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '422':
+          description: Unprocessable Entity
+          x-errors:
+          - code: unprocessable_entity
+            category: base
+            message: Payment should be in 'Completed' or 'Failed' status
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/{id}/submission_info:
+    get:
+      tags:
+      - Payments
+      summary: Get Payment Submission Information
+      description: Gets the pacs.008 or MT103 information for a Swift payment.
+      operationId: GetNewPaymentSubmission
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentSubmissionInformation'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: ID should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: on_behalf_of_is_not_valid_UUID
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: payment_not_found
+            category: id
+            message: Payment was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentSubmissionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/authorise:
+    post:
+      tags:
+      - Payments
+      summary: Authorise Payment
+      description: Authorises a payment pending authorisation.
+      operationId: AuthorisePayment
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: payment_ids[]
+        in: query
+        description: One or more payment UUID identifiers to be authorised.
+        required: true
+        schema:
+          type: array
+          format: uuid
+          items:
+            type: string
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentAuthorisations'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: payment_ids_is_required
+            category: id
+            message: payment_ids is required
+            params: ''
+          - code: payment_ids_type_is_wrong
+            category: id
+            message: payment_ids should be of array type
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatePaymentAuthorisationError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/{id}/delete:
+    post:
+      tags:
+      - Payments
+      summary: Delete Payment
+      description: Delete a payment. On success, returns the final payment record state.
+      operationId: DeletePayment
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_id
+            category: id
+            message: ID has invalid format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: payment_not_found
+            category: id
+            message: Payment was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletePaymentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/{id}/tracking_info:
+    get:
+      tags:
+      - Payments
+      summary: Get Payment Tracking Information
+      description: Gets the tracking information for a payment.
+      operationId: GetPaymentTrackingInfo
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentTrackingInfo'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: payment_id_is_not_valid_uuid
+            category: id
+            message: payment_id should be in UUID format
+            params: ''
+          - code: payment_is_not_swift
+            category: base
+            message: You cannot track non-swift payments
+            params: ''
+          - code: payment_is_not_executed
+            category: base
+            message: This payment is not executed yet, please try again later
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentTrackingInfoError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: You do not have permission 'payment_tracking' to perform this operation
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/assign_payment_fee:
+    post:
+      tags:
+      - Payments
+      summary: Assign Payment Fee
+      description: Assigns a <a href="https://support.currencycloud.com/hc/en-gb/articles/360017471459-Applying-fees-to-individual-payments-FAQ">payment
+        fee</a> table to a specific sub-account.
+      operationId: PaymentsAssignPaymentFee
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                payment_fee_id:
+                  type: string
+                  format: uuid
+                  description: ID of the payment fee entity that will be assigned to the account.
+                account_id:
+                  type: string
+                  format: uuid
+                  description: ID of the account to which the payment fee will be assigned.
+              required:
+              - payment_fee_id
+              - account_id
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentFeeAssignment'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: payment_fee_id_is_required
+            category: payment_fee_id
+            message: payment_fee_id is required
+            params: ''
+          - code: payment_fee_id_is_not_valid_uuid
+            category: payment_fee_id
+            message: payment_fee_id should be in UUID format
+            params: ''
+          - code: account_id_is_required
+            category: account_id
+            message: account_id is required
+            params: ''
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: ''
+          - code: account_configuration_is_invalid
+            category: base
+            message: Account is not enabled for CashManager or NewPaymentRelease flow
+            params: ''
+          - code: account_operation_restricted
+            category: base
+            message: Operation restricted for the account
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentFeeAssignmentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: permission_denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/payment_delivery_date:
+    get:
+      tags:
+      - Payments
+      summary: Get Payment Delivery Date
+      description: Gets payment delivery date.
+      operationId: GetPaymentDeliveryDate
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: payment_date
+        in: query
+        description: The date when the payment will be released. Any valid ISO 8601 format, e.g. "2023-12-31".
+        required: true
+        schema:
+          type: string
+          format: date
+      - name: payment_type
+        in: query
+        description: 'Currencycloud supports two types of payments: "priority", made using the Swift network; and "regular",
+          made using the local bank network.'
+        required: true
+        schema:
+          type: string
+          enum:
+          - priority
+          - regular
+      - name: currency
+        in: query
+        description: The three-letter ISO code of the currency of the payment.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: bank_country
+        in: query
+        description: The two-letter ISO code of the country where the payment is sent.
+        required: true
+        schema:
+          type: string
+          format: iso3166-1-alpha-2
+          pattern: ^[A-Z]{2}$
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentDeliveryDate'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: bank_country_is_required
+            category: bank_country
+            message: bank_country is required
+            params: ''
+          - code: bank_country_is_in_invalid_format
+            category: bank_country
+            message: bank_country is in invalid format
+            params: ''
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: Currency is not a valid ISO 4217 currency code
+            params: ''
+          - code: payment_type_is_required
+            category: payment_type
+            message: payment_type is required
+            params: ''
+          - code: payment_type_not_in_range
+            category: payment_type
+            message: 'payment_type should be in range: priority, regular'
+            params: '{ "range" => "priority, regular" }'
+          - code: invalid_payment
+            category: base
+            message: Payment cannot be processed
+            params: ''
+          - code: invalid_currency
+            category: currency
+            message: You cannot make payments with this currency
+            params: ''
+          - code: payment_date_is_required
+            category: payment_date
+            message: payment_date is required
+            params: ''
+          - code: invalid_payment_date
+            category: payment_date
+            message: The payment date is invalid
+            params: ''
+          - code: payment_date_is_in_invalid_format
+            category: payment_date
+            message: payment_date should be in ISO 8601 format
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentDeliveryDateError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/payment_fees:
+    get:
+      tags:
+      - Payments
+      summary: Get Payment Fees
+      description: Gets the <a href="https://support.currencycloud.com/hc/en-gb/articles/360017471459-Applying-fees-to-individual-payments-FAQ">payment
+        fee</a> tables for the current authenticated account.
+      operationId: GetPaymentPaymentFees
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: Any field name to change the sort order.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payment_fees:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PaymentFee'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: permission_denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/quote_payment_fee:
+    get:
+      tags:
+      - Payments
+      summary: Get Quote Payment Fee
+      description: Gets the calculated quote for the fee that will be applied against a payment.
+      operationId: GetQuotePaymentFee
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: account_id
+        in: query
+        description: Account UUID. If this is left empty, the account that is making the API call is used.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: payment_currency
+        in: query
+        description: Currency of the payment.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: payment_destination_country
+        in: query
+        description: Destination Country of the payment.
+        required: true
+        schema:
+          type: string
+          format: iso3166-1-alpha-2
+          pattern: ^[A-Z]{2}$
+      - name: payment_type
+        in: query
+        description: Type of payment - priority(Swift) or regular(local).
+        required: true
+        schema:
+          type: string
+          enum:
+          - priority
+          - regular
+      - name: charge_type
+        in: query
+        description: Payment Charges type. if no value is provided the account's default value is used.
+        required: false
+        schema:
+          type: string
+          enum:
+          - ours
+          - shared
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuotePaymentFee'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: '{"type" => "currency"}'
+          - code: payment_currency_is_required
+            category: payment_currency
+            message: payment_currency is required
+            params: ''
+          - code: payment_currency_is_in_invalid_format
+            category: payment_currency
+            message: payment_currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: payment_destination_country_is_required
+            category: payment_destination_country
+            message: payment_destination_country is required
+            params: ''
+          - code: payment_destination_country_is_in_invalid_format
+            category: payment_destination_country
+            message: payment_destination_country is in invalid format
+            params: '{"type"=> "country_code"}'
+          - code: charge_type_is_required
+            category: charge_type
+            message: charge_type is required
+            params: ''
+          - code: charge_type_not_in_range
+            category: charge_type
+            message: 'charge_type should be in range: shared, ours'
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: payment_type_not_in_range
+            category: payment_type
+            message: 'payment_type should be in range: priority, regular'
+            params: '{ "payment_type" => "priority, regular" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetQuotePaymentFeeError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/unassign_payment_fee:
+    post:
+      tags:
+      - Payments
+      summary: Unassign Payment Fee
+      description: Unassigns the <a href="https://support.currencycloud.com/hc/en-gb/articles/360017471459-Applying-fees-to-individual-payments-FAQ">payment
+        fee</a> tables for a specific sub-account.
+      operationId: PaymentsUnassignPaymentFee
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                account_id:
+                  type: string
+                  format: uuid
+                  description: Sub-account UUID for which the payment level fee will be un-assigned.
+              required:
+              - account_id
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentFeeUnassignment'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_id_is_required
+            category: account_id
+            message: account_id is required
+            params: ''
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: ''
+          - code: account_configuration_is_invalid
+            category: base
+            message: Account is not enabled for CashManager or NewPaymentRelease flow
+            params: ''
+          - code: account_operation_restricted
+            category: base
+            message: Operation restricted for the account
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentFeeUnassignmentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: permission_denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/validate:
+    post:
+      tags:
+      - Payments
+      summary: Validate Payment
+      description: 'Validates the details of a new payment without creating a record of the payment. On success, returns an
+        object containing a string validation_result with value "success".<br><br>
+
+        Clients who are implementing Strong Customer Authentication (SCA) for payments should refer to our <strong><a href="../guides/integration-guides/sca_sponsored_api_payments">SCA
+        for payments integration guide</a></strong>.'
+      operationId: ValidatePayment
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: x-sca-to-authenticated-user
+        in: header
+        description: Setting this to true will send the OTP to the authenticated user instead of the on-behalf-of customer.
+          This option is only available to clients on specific licensing models.
+        required: false
+        schema:
+          type: boolean
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: Payment UUID
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency in which payment is made. Three-digit currency code.
+                  pattern: ^[A-Z]{3}$
+                beneficiary_id:
+                  type: string
+                  format: uuid
+                  description: Beneficiary UUID
+                amount:
+                  type: string
+                  description: Amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                reason:
+                  type: string
+                  description: User-generated reason for payment - freeform text.
+                  minLength: 1
+                  maxLength: 255
+                reference:
+                  type: string
+                  description: User-generated reference code.
+                  minLength: 1
+                  maxLength: 255
+                payment_date:
+                  type: string
+                  format: date
+                  description: Instructed date of payment. Any valid ISO 8601 format, e.g. "2023-12-31".
+                payment_type:
+                  type: string
+                  description: 'Currencycloud supports two types of payments: "priority", made using the Swift network; and
+                    "regular", made using the local bank network.'
+                  enum:
+                  - priority
+                  - regular
+                conversion_id:
+                  type: string
+                  format: uuid
+                  description: Conversion UUID
+                payer_entity_type:
+                  type: string
+                  description: Legal entity
+                  enum:
+                  - company
+                  - individual
+                payer_company_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "company".
+                  minLength: 1
+                  maxLength: 255
+                payer_first_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                payer_last_name:
+                  type: string
+                  description: Required if "payer_entity_type" is "individual".
+                  minLength: 1
+                  maxLength: 255
+                payer_city:
+                  type: string
+                  description: City
+                  minLength: 1
+                  maxLength: 255
+                payer_address:
+                  type: string
+                  description: First line of address.
+                  minLength: 1
+                  maxLength: 255
+                payer_postcode:
+                  type: string
+                  description: Postal code
+                  minLength: 1
+                  maxLength: 255
+                payer_state_or_province:
+                  type: string
+                  description: State or province.
+                  minLength: 1
+                  maxLength: 255
+                payer_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two-letter ISO country code.
+                  pattern: ^[A-Z]{2}$
+                payer_date_of_birth:
+                  type: string
+                  format: date
+                  description: If "payer_entity_type" is "company", this is the company registration date. If "payer_entity_type"
+                    is "individual", this is the individual's date of birth. ISO 8601 format YYYY-MM-DD.
+                payer_identification_type:
+                  type: string
+                  description: A legal document that verifies the identity of the payer. Required documentation will vary
+                    depending on the nationality or registered address of the payer.
+                  enum:
+                  - citizenship_papers
+                  - credential_de_elector
+                  - drivers_license
+                  - drivers_license_canadian
+                  - employer_identification_number
+                  - existing_credit_card_details
+                  - green_card
+                  - incorporation_number
+                  - matricula_consular
+                  - national_id
+                  - none
+                  - others
+                  - passport
+                  - registro_federal_de_contribuyentes
+                  - social_insurance_number
+                  - social_security_number
+                  - visa
+                payer_identification_value:
+                  type: string
+                  description: A unique reference code for the identification document, such as a passport number.
+                  minLength: 1
+                  maxLength: 255
+                unique_request_id:
+                  type: string
+                  description: User-generated idempotency key.
+                  minLength: 1
+                  maxLength: 255
+                ultimate_beneficiary_name:
+                  type: string
+                  description: The name of the ultimate beneficiary if different.
+                  minLength: 1
+                  maxLength: 255
+                purpose_code:
+                  type: string
+                  description: Payment Purpose Code (Mandatory for all INR payments).
+                  minLength: 1
+                  maxLength: 255
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                charge_type:
+                  type: string
+                  description: Payment Charges Setting value (only applicable to Swift payments). If empty - then account's
+                    default value is used. Do not specify for regular (local) payments.
+                  enum:
+                  - ours
+                  - shared
+                fee_amount:
+                  type: string
+                  description: Fee amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                fee_currency:
+                  type: string
+                  format: iso-4217
+                  description: Currency fee is paid in.
+                  pattern: ^[A-Z]{3}$
+                payer_ultimate_account_number:
+                  type: string
+                  description: The payer's payment account number.
+                  maxLength: 35
+              required:
+              - currency
+              - beneficiary_id
+              - amount
+              - reason
+              - reference
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  validation_result:
+                    type: string
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+            x-sca-required:
+              description: true if SCA is required to create the payment.
+              schema:
+                type: boolean
+            x-sca-id:
+              description: UUID to correlate to the SCA request.
+              schema:
+                type: string
+            x-sca-type:
+              description: Type of SCA applied to the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: invalid_type
+            category: type
+            message: Invalid Payment type
+            params: ''
+          - code: payment_type_not_in_range
+            category: type
+            message: 'payment_type should be in range: priority, regular'
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: type
+            message: currency is not a valid ISO 4217 currency code
+            params: ''
+          - code: currency_length_is_invalid
+            category: currency
+            message: currency should be 3 character(s) long
+            params: ''
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: invalid_currency
+            category: currency
+            message: You cannot make payments with this currency
+            params: ''
+          - code: beneficiary_id_is_not_valid_uuid
+            category: beneficiary_id
+            message: beneficiary_id should be in UUID format
+            params: ''
+          - code: beneficiary_id_is_required
+            category: beneficiary_id
+            message: beneficiary_id is required
+            params: ''
+          - code: invalid_beneficiary_currency
+            category: beneficiary_currency
+            message: You cannot assign this Beneficiary to the Payment as it is the incorrect currency
+            params: ''
+          - code: invalid_beneficiary_id
+            category: beneficiary_id
+            message: Unknown beneficiary_id
+            params: ''
+          - code: payment_above_limit
+            category: amount
+            message: 3000.00 EUR exceeds the maximum amount of 2500.00 EUR for a local payment.
+            params: ''
+          - code: payer_entity_type_not_in_range
+            category: payer_entity_type
+            message: 'payer_entity_type should be in range: individual, company'
+            params: ''
+          - code: payer_details_are_missing
+            category: payer_entity_type
+            message: 'Following payer details are missing: payer_entity_type, payer_company_name, payer_first_name, payer_last_name,
+              payer_city, payer_address, payer_state_or_province, payer_postcode, payer_country, payer_date_of_birth, payer_identification_type,
+              payer_identification_value, payer_ultimate_account_number'
+            params: '{"missing_details" => "payer_entity_type, payer_company_name, payer_first_name, payer_last_name, payer_city,
+              payer_address, payer_state_or_province, payer_postcode, payer_country, payer_date_of_birth, payer_identification_type,
+              payer_identification_value, payer_ultimate_account_number"}'
+          - code: unsupported_payer_country_code
+            category: payer_country_code
+            message: Payer country is not supported
+            params: ''
+          - code: payer_country_is_in_invalid_format
+            category: payer_country
+            message: payer_country is not a valid ISO 3166-1 Alpha-2 country code
+            params: ''
+          - code: payer_date_of_birth_type_is_wrong
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be of date type
+            params: '{ "type" => "date" }'
+          - code: payer_date_of_birth_is_incorrect
+            category: payer_date_of_birth
+            message: payer_date_of_birth is incorrect
+            params: ''
+          - code: payer_date_of_birth_is_earlier
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be later
+            params: ''
+          - code: payer_date_of_birth_is_after
+            category: payer_date_of_birth
+            message: payer_date_of_birth should be earlier
+            params: ''
+          - code: invalid_conversion_id
+            category: conversion_id
+            message: Conversion could not be found
+            params: ''
+          - code: conversion_is_already_settled
+            category: conversion_id
+            message: The conversion is already settled
+            params: ''
+          - code: invalid_amount_for_conversion
+            category: conversion_id
+            message: The payment amount is more than the value of the conversion
+            params: ''
+          - code: payment_date_type_is_wrong
+            category: payment_date
+            message: payment_date should be of date type
+            params: ''
+          - code: payment_date_is_too_early
+            category: payment_date
+            message: The payment date cannot be sooner than the conversion date
+            params: ''
+          - code: reason_is_too_long
+            category: reference
+            message: reference can not be longer than 255 character(s)
+            params: ''
+          - code: reference_is_too_long
+            category: reference
+            message: reference can not be longer than 255 character(s)
+            params: ''
+          - code: id_is_not_valid_uuid
+            category: reference
+            message: id should be in UUID format
+            params: ''
+          - code: charge_type_not_available
+            category: charge_type
+            message: Not available charge_type has been provided
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: charge_type_not_in_range
+            category: charge_type
+            message: 'charge_type should be in range: ours, shared'
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: on_behalf_of_is_not_valid_UUID
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: on_behalf_of_charge_type_not_available
+            category: on_behalf_of
+            message: Not available charge_type has been provided for on_behalf_of
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: duplicate_request
+            category: duplicate_request
+            message: The unique_request_id provided for this payment has already been used, please provide a new unique_request_id
+              to successfully submit this payment
+            params: ''
+          - code: fee_amount_type_is_wrong
+            category: fee_amount
+            message: fee_amount should be of numeric type
+            params: '{ "type" => "numeric" }'
+          - code: fee_currency_is_in_invalid_format
+            category: fee_currency
+            message: fee_currency is not a valid ISO 4217 currency code
+            params: '{ "type" => "currency" }'
+          - code: purpose_code_is_missing
+            category: purpose_code
+            message: Purpose code is missing
+            params: ''
+          - code: incorrect_purpose_code
+            category: purpose_code
+            message: Purpose code is invalid
+            params: ''
+          - code: unsupported_beneficiary_country_code
+            category: beneficiary_country_code
+            message: Beneficiary country is not supported
+            params: ''
+          - code: invalid_extra_parameters
+            category: base
+            message: Invalid extra parameters extra_parameter
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidatePaymentError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payments/{id}/notifications/retry:
+    post:
+      tags:
+      - Payments
+      summary: Resend Payment Notification
+      description: Resends a payment notification for the specified payment ID.
+      operationId: PaymentsRetryNotifications
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payment UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: notification_type
+        in: query
+        description: The notification to be resent.
+        required: true
+        schema:
+          type: string
+          enum:
+          - payment_ready_to_send_notification
+          - payment_released_notification
+          - payment_failed_notification
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: payment_not_found
+            category: id
+            message: Payment was not found for this id
+            params: ''
+          - code: notification_type_not_in_range
+            category: notification_type
+            message: 'notification_type should be in range: payment_ready_to_send_notification, payment_released_notification,
+              payment_failed_notification'
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetryNotificationError'
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporary unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /payers/{id}:
+    get:
+      tags:
+      - Payers
+      summary: Get Payer
+      description: Get a payer record.
+      operationId: GetPayer
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Payer UUID.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payer'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: payer_not_found
+            category: id
+            message: Payer was not found for this id
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPayerError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /rates/find:
+    get:
+      tags:
+      - Rates
+      summary: Get Basic Rates
+      description: Gets indicative foreign exchange rate information for one or more currency pairs in a single request. <br><br>
+        This endpoint is intended to provide an indication of the rate available in the market and can support requests for
+        multiple currency pairs, so is good for polling requirements such as live FX ticker widgets. This endpoint should
+        be used where speed, availability and the ability to request multiple currency pairs is important.
+      operationId: GetBasicRates
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: currency_pair
+        in: query
+        description: Concatenated string of the two currencies traded, e.g. "USDEUR". More than one pair can be entered, separated
+          by a comma e.g. "EURGBP,GBPUSD,EURUSD".
+        required: true
+        schema:
+          type: string
+          pattern: ^[A-Z]{6}$
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: ignore_invalid_pairs
+        in: query
+        description: Ignore the validation of currency pairs.
+        required: false
+        schema:
+          type: boolean
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RatesBasic'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: currency_pair_is_too_long
+            category: currency_pair
+            message: currency_pair can not be longer than 2450 character(s)
+            params: '{ "maxlength" => 2450 }'
+          - code: currency_pair_is_too_short
+            category: currency_pair
+            message: currency_pair can not be shorter than 6 letter(s)
+            params: '{ "minlength" => 6 }'
+          - code: currency_pair_is_required
+            category: currency_pair
+            message: currency_pair is required
+            params: ''
+          - code: invalid_currency_pair
+            category: currency_pair
+            message: Invalid currency pair
+            params: '{ "currency_pair" => ["AAABBB"] }'
+          - code: ignore_invalid_pairs_type_is_wrong
+            category: currency_pair
+            message: ignore_invalid_pairs should be of boolean type
+            params: '{ "ignore_invalid_pairs": "not_true" }'
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetBasicRatesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /rates/detailed:
+    get:
+      tags:
+      - Rates
+      summary: Get Detailed Rates
+      description: Gets a detailed, tradeable rate quote to convert money from one currency to another. The quotation provided
+        will be based on the spread table of the authenticated user. There is also the option to provide a specific date for
+        the conversion to occur. <br><br> This endpoint provides a current tradeable rate for a single currency pair. It should
+        be used as the start of the flow before a conversion is booked. This endpoint should be used where accuracy is the
+        most important aspect, such as when a trade is about to be booked.
+      operationId: GetDetailedRates
+      x-api-group: convert
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: buy_currency
+        in: query
+        description: Currency purchased - three-letter ISO code.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: sell_currency
+        in: query
+        description: Currency sold - three-letter ISO code.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: fixed_side
+        in: query
+        description: Fix the buy or sell currency.
+        required: true
+        schema:
+          type: string
+          enum:
+          - buy
+          - sell
+      - name: amount
+        in: query
+        description: Amount of the fixed buy or sell currency.
+        required: true
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: conversion_date
+        in: query
+        description: Date of delivery of purchased currency. ISO 8601 format YYYY-MM-DD. If not specified, deals settle in
+          two working days.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: conversion_date_preference
+        in: query
+        description: Available only if conversion_date is not provided. Must be one of the following:<br> 'earliest' for earliest
+          available conversion date. Make sure there is sufficient time to send funds to Currencycloud.<br> 'next_day' for
+          next day available conversion date - T+1.<br> 'default' for conversion - T+1 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC
+          restricted currencies</a>, T+2 for all others.<br> 'optimize_liquidity' for maximizing chances of getting a successful
+          rate. Most relevant for exotic pairs. Conversion is T+0 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC
+          restricted currencies</a>, and T+1 or T+2 for all others.
+        required: false
+        schema:
+          type: string
+          enum:
+          - default
+          - earliest
+          - next_day
+          - optimize_liquidity
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateDetailed'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: unique_value_parameters
+            category: base
+            message: 'Following parameters should not have same values: sell_currency, buy_currency'
+            params: '{ "parameters" => "sell_currency, buy_currency" }'
+          - code: rate_could_not_be_retrieved
+            category: base
+            message: Rate could not be retrieved
+            params: ''
+          - code: ccy_pair_is_not_tradeable
+            category: base
+            message: Given currency pair is not tradeable
+            params: ''
+          - code: fixed_side_not_in_range
+            category: fixed_side
+            message: 'fixed_side should be in range: sell, buy'
+            params: '{ "range" => "sell, buy" }'
+          - code: fixed_side_is_required
+            category: fixed_side
+            message: fixed_side is required
+            params: ''
+          - code: conversion_date_type_is_wrong
+            category: conversion_date
+            message: conversion_date should be of date type
+            params: '{ "type" => "date" }'
+          - code: invalid_delivery_date
+            category: conversion_date
+            message: The delivery date you have requested cannot be met for this currency pair
+            params: ''
+          - code: sell_currency_is_in_invalid_format
+            category: sell_currency
+            message: sell_currency is in invalid format
+            params: ''
+          - code: sell_currency_is_required
+            category: sell_currency
+            message: sell_currency is required
+            params: ''
+          - code: currency_pair_not_available_for_weekend
+            category: currency_pair_not_available_for_weekend
+            message: Currency pair is not available for weekend
+            params: ''
+          - code: amount_type_is_wrong
+            category: amount
+            message: amount should be of numeric type
+            params: '{ "type" => "numeric" }'
+          - code: amount_is_required
+            category: amount
+            message: amount is required
+            params: ''
+          - code: amount_is_too_small
+            category: amount
+            message: amount can not be smaller than 1
+            params: '{ "minvalue" => 1 }'
+          - code: buy_currency_is_in_invalid_format
+            category: buy_currency
+            message: buy_currency is in invalid format
+            params: ''
+          - code: buy_currency_is_required
+            category: buy_currency
+            message: buy_currency is required
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: amount_is_in_invalid_format
+            category: amount
+            message: amount should be of numeric type with 2 dp
+            params: '{ "type" => "numeric_with_precision", "precision" => 2 }'
+          - code: invalid_conversion_date_combination
+            category: base
+            message: conversion_date_preference can not be specified along side a date parameter
+            params: ''
+          - code: invalid_conversion_date_preference
+            category: base
+            message: not a valid conversion date preference, possible options are earliest, optimize_liquidity, default, next_day
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetDetailedRatesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/bank_details/find:
+    post:
+      tags:
+      - Reference
+      summary: Find Bank Details
+      description: Returns the related bank details for the given account reference.
+      operationId: FindBankDetailsPost
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                identifier_type:
+                  type: string
+                  description: The type of code used to identify the account (e.g. IBAN).
+                  enum:
+                  - aba
+                  - bic_swift
+                  - bsb_code
+                  - cnaps
+                  - iban
+                  - ifsc
+                  - routing_number
+                  - sort_code
+                identifier_value:
+                  type: string
+                  description: The value of the account identifier specified in identifier_type (e.g. the IBAN code).
+                  minLength: 1
+                  maxLength: 255
+              required:
+              - identifier_type
+              - identifier_value
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BankDetails'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: identifier_type_is_required
+            category: identifier_type
+            message: identifier_type is required
+            params: ''
+          - code: identifier_type_not_in_range
+            category: identifier_type
+            message: 'identifier_type should be in range: iban, bic_swift, sort_code, aba, bsb_code, routing_number, cnaps,
+              ifsc'
+            params: '{ "range" => "iban, bic_swift, sort_code, aba, bsb_code, routing_number, cnaps, ifsc" }'
+          - code: identifier_value_is_required
+            category: identifier_value
+            message: identifier_value is required
+            params: ''
+          - code: identifier_value_is_empty
+            category: identifier_value
+            message: identifier_value should not be empty
+            params: '{ "type" => "not_empty_string" }'
+          - code: invalid_iban
+            category: base
+            message: IBAN is invalid
+            params: ''
+          - code: invalid_bic
+            category: base
+            message: BIC_Swift is invalid
+            params: ''
+          - code: invalid_aba
+            category: base
+            message: ABA is invalid
+            params: ''
+          - code: invalid_sort_code
+            category: base
+            message: SORT_CODE is invalid
+            params: ''
+          - code: invalid_bsb
+            category: base
+            message: BSB_CODE is invalid
+            params: ''
+          - code: invalid_routing_number
+            category: base
+            message: ROUTING_NUMBER is invalid
+            params: ''
+          - code: invalid_cnaps
+            category: base
+            message: CNAPS is invalid
+            params: ''
+          - code: cannot_retrieve_bank_data
+            category: base
+            message: Bank Details service is temporarily unavailable
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetBankDetailsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error s
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable.
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/beneficiary_required_details:
+    get:
+      tags:
+      - Reference
+      summary: Get Beneficiary Requirements
+      description: Returns the information that is required to make payments to beneficiaries in specified currencies and
+        countries.
+      operationId: GetBeneficiaryRequirements
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: currency
+        in: query
+        description: Currency in which money is held in the beneficiary's bank account. Three-letter ISO currency code.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: bank_account_country
+        in: query
+        description: Two-letter ISO country code.
+        required: true
+        schema:
+          type: string
+          format: iso3166-1-alpha-2
+          pattern: ^[A-Z]{2}$
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: beneficiary_country
+        in: query
+        description: Two-letter ISO country code. If the beneficiary is a company, this is the country in which the company
+          is registered. If the beneficiary is an individual, this is the country in which they are based.
+        required: true
+        schema:
+          type: string
+          format: iso3166-1-alpha-2
+          pattern: ^[A-Z]{2}$
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  details:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/BeneficiaryRequirements'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: bank_account_country_is_in_invalid_format
+            category: bank_account_country
+            message: Bank account country is not a valid ISO 3166-1 Alpha-2 country code
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: Currency is not a valid ISO 4217 currency code
+            params: ''
+          - code: beneficiary_country_is_in_invalid_format
+            category: beneficiary_country
+            message: Beneficiary country is not a valid ISO 3166-1 Alpha-2 country code
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetBeneficiaryRequirementsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/conversion_dates:
+    get:
+      tags:
+      - Reference
+      summary: Get Conversion Dates
+      description: Provides a list of upcoming non-trading dates, such as weekends or public holidays, for a specified currency
+        pair. Common use cases include situations where this information needs to be provided, or for planning upcoming conversion
+        bookings. <br><br> Many currencies are triangulated; this means that holidays affecting the intermediary currency,
+        as well as the sale and purchase currencies, will impact transactions. Find out more at our <a href="https://support.currencycloud.com/hc/en-gb/articles/5223342659484-Currency-Triangulation">support
+        article.</a>
+      operationId: GetConversionDates
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: conversion_pair
+        in: query
+        description: Concatenated string of the currency codes for the two currencies involved, e.g. "USDEUR".
+        required: true
+        schema:
+          type: string
+          pattern: ^[A-Z]{6}$
+      - name: start_date
+        in: query
+        description: Start date of conversion. ISO 8601 format YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversionDates'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: conversion_pair_is_required
+            category: conversion_pair
+            message: conversion_pair is required
+            params: ''
+          - code: invalid_conversion_pair
+            category: conversion_pair
+            message: The conversion pair specified was invalid
+            params: ''
+          - code: conversion_pair_is_too_short
+            category: conversion_pair
+            message: conversion_pair can not be shorter than 6 character(s)
+            params: '{ "minlength" => 6 }'
+          - code: conversion_pair_is_too_long
+            category: conversion_pair
+            message: conversion_pair can not be longer than 6 character(s)
+            params: '{ "maxlength" => 6 }'
+          - code: start_date_is_too_far_in_future
+            category: start_date
+            message: Date is too far in the future (more than 1 year)
+            params: '{ "maxdate" => "2015-04-04T00:00:00Z", "period" => "1 year" }'
+          - code: start_date_is_in_invalid_format
+            category: start_date
+            message: start_date should be in ISO 8601 format
+            params: '{ "type" => "date" }'
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You can not act on behalf of your own Contact
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetConversionDatesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/currencies:
+    get:
+      tags:
+      - Reference
+      summary: Get Available Currencies
+      description: Gets a list of all currencies that can be traded on the Currencycloud platform.
+      operationId: GetAvailableCurrencies
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AvailableCurrencies'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAvailableCurrenciesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/payer_required_details:
+    get:
+      tags:
+      - Reference
+      summary: Get Payer Requirements
+      description: Returns the payer information you need to provide to create a payment. Requirements vary depending on the
+        location of the payer, the type of payment to be made (priority or regular), and other factors.
+      operationId: GetPayerRequirements
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: payer_country
+        in: query
+        description: Two-letter ISO country code.
+        required: true
+        schema:
+          type: string
+          format: iso3166-1-alpha-2
+          pattern: ^[A-Z]{2}$
+      - name: payer_entity_type
+        in: query
+        description: Legal entity type - company or individual.
+        required: false
+        schema:
+          type: string
+          enum:
+          - company
+          - individual
+      - name: payment_type
+        in: query
+        description: 'Currencycloud supports two types of payments: "priority" (Swift), made using the Swift network; and
+          "regular" (local), made using the local bank network.'
+        required: false
+        schema:
+          type: string
+          enum:
+          - priority
+          - regular
+      - name: currency
+        in: query
+        description: Three-letter ISO 4217 currency code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PayerRequirements'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: payer_country_is_required
+            category: payer_country
+            message: payer_country is required
+            params: ''
+          - code: payer_country_is_in_invalid_format
+            category: payer_country
+            message: payer_country is not a valid ISO 3166-1 Alpha-2 country code
+            params: '{ "type" => "country_code" }'
+          - code: payment_type_not_in_range
+            category: payment_type
+            message: 'payment_type should be in range: priority, regular'
+            params: '{ "range" => "priority, regular" }'
+          - code: payer_entity_type_not_in_range
+            category: payer_entity_type
+            message: 'payer_entity_type should be in range: company, individual'
+            params: '{ "range" => "company, individual" }'
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPayerRequirementsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/payment_dates:
+    get:
+      tags:
+      - Reference
+      summary: Get Payment Dates
+      description: Gets a list of invalid payment dates for a given currency covering a two months period from the start_date
+        specified. A payment date is when a payment will be executed by Currencycloud. Payments cannot be made on some days,
+        for example when banks are closed.
+      operationId: GetPaymentDates
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: currency
+        in: query
+        description: Currency in which payment made. Three-letter ISO currency code.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: start_date
+        in: query
+        description: Payment start date, defaults to today's date. ISO 8601 format YYYY-MM-DD.
+        required: false
+        schema:
+          type: string
+          format: date
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaymentDates'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code
+            params: ''
+          - code: start_date_is_too_far_in_future
+            category: start_date
+            message: Date is too far in the future (more than 1 year)
+            params: '{ "maxdate" => "2015-04-04T00:00:00Z", "period" => "1 year" }'
+          - code: start_date_is_in_invalid_format
+            category: start_date
+            message: start_date should be in ISO 8601 format
+            params: '{ "type" => "datetime" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentDatesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/payment_fee_rules:
+    get:
+      tags:
+      - Reference
+      summary: Get Payment Fee Rules
+      description: Gets the <a href="https://support.currencycloud.com/hc/en-gb/articles/360017471459-Applying-fees-to-individual-payments-FAQ">payment
+        fee</a> information set up for the account / payment type provided.
+      operationId: GetPaymentFeeRules
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: account_id
+        in: query
+        description: Account UUID
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: payment_type
+        in: query
+        description: Payment type value. Limits the search results to payments of the specified payment type - 'priority'(Swift)
+          or 'regular'(local).
+        required: false
+        schema:
+          type: string
+          enum:
+          - priority
+          - regular
+      - name: charge_type
+        in: query
+        description: Payment charge value. Limits the search results to payments of the specified <a href="https://support.currencycloud.com/hc/en-gb/articles/360017430820-Selecting-payment-charges-for-SWIFT-payments-FAQ">charge
+          type</a> - 'ours' or 'shared'.
+        required: false
+        schema:
+          type: string
+          enum:
+          - ours
+          - shared
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  payment_fee_rules:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PaymentFeeRule'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: ''
+          - code: charge_type_not_in_range
+            category: charge_type
+            message: 'charge_type should be in range: shared, ours'
+            params: '{ "charge_type" => "shared, ours" }'
+          - code: payment_type_not_in_range
+            category: payment_type
+            message: 'payment_type should be in range: priority, regular'
+            params: '{ "payment_type" => "priority, regular" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentFeeRulesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/payment_purpose_codes:
+    get:
+      tags:
+      - Reference
+      summary: Get Payment Purpose Codes
+      description: Gets a list of payment purpose codes for a given currency and entity type. When initiating cross-border
+        payments, the central bank of the country may require a purpose to be included with your transaction in order for
+        your payment to be accepted and processed. If a payment purpose code is required but not provided, your payment may
+        be delayed or rejected by the beneficiary bank.
+      operationId: GetPaymentPurposeCodes
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: currency
+        in: query
+        description: Three-letter ISO currency code for the currency in which payment will be made. No purpose codes will
+          be returned if an invalid currency code is given.
+        required: true
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: entity_type
+        in: query
+        description: Legal entity type - company or individual.
+        required: false
+        schema:
+          type: string
+          enum:
+          - company
+          - individual
+      - name: bank_account_country
+        in: query
+        description: Two-letter ISO country code of the bank account.
+        required: true
+        schema:
+          type: string
+          format: iso3166-1-alpha-2
+          pattern: ^[A-Z]{2}$
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  purpose_codes:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PaymentPurposeCodes'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: currency_is_required
+            category: currency
+            message: currency is required
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetPaymentPurposeCodesError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          - code: missing_translation
+            category: base
+            message: Internal server error. Currency value was not specified
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reference/settlement_accounts:
+    get:
+      tags:
+      - Reference
+      summary: Get Settlement Accounts
+      description: Gets settlement account information - a list of accounts that require funding in order to allow for outstanding
+        transactions to be processed.
+      operationId: GetSettlementAccounts
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: currency
+        in: query
+        description: Three-letter ISO currency code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: account_id
+        in: query
+        description: Account UUID
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  settlement_accounts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/SettlementAccount'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_id_is_not_valid_uuid
+            category: id
+            message: account_id should be in UUID format
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: currency is not a valid ISO 4217 currency code.
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSettlementAccountsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: account_not_found
+            category: base
+            message: Account was not found for this id
+            params: ''
+          - code: settlement_accounts_not_found
+            category: base
+            message: Settlement Account details not found
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reports/conversions/create:
+    post:
+      tags:
+      - Reporting
+      summary: Generate Conversion Report
+      description: Returns a JSON structure with details of the conversion report requested.
+      operationId: GenerateConversionReport
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                description:
+                  type: string
+                  description: Description that will be applied to the report.
+                  minLength: 1
+                  maxLength: 255
+                buy_currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-letter ISO 4217 currency code.
+                  pattern: ^[A-Z]{3}$
+                sell_currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-letter ISO 4217 currency code.
+                  pattern: ^[A-Z]{3}$
+                client_buy_amount_from:
+                  type: string
+                  format: numeric
+                  description: Minimum client buy amount.
+                client_buy_amount_to:
+                  type: string
+                  format: numeric
+                  description: Maximum client buy amount.
+                client_sell_amount_from:
+                  type: string
+                  format: numeric
+                  description: Minimum client sell amount.
+                client_sell_amount_to:
+                  type: string
+                  format: numeric
+                  description: Maximum client sell amount.
+                partner_buy_amount_from:
+                  type: string
+                  format: numeric
+                  description: Minimum buy amount (sub-accounts).
+                  pattern: ^\d+(\.\d{1,3})?$
+                partner_buy_amount_to:
+                  type: string
+                  format: numeric
+                  description: Maximum buy amount (sub-accounts).
+                  pattern: ^\d+(\.\d{1,3})?$
+                partner_sell_amount_from:
+                  type: string
+                  format: numeric
+                  description: Minimum sell amount (sub-accounts).
+                  pattern: ^\d+(\.\d{1,3})?$
+                partner_sell_amount_to:
+                  type: string
+                  format: numeric
+                  description: Maximum sell amount (sub-accounts).
+                  pattern: ^\d+(\.\d{1,3})?$
+                client_status:
+                  type: string
+                  description: The current status of the conversion.
+                  enum:
+                  - awaiting_funds
+                  - funds_sent
+                  - funds_arrived
+                  - trade_settled
+                  - awaiting_authorisation
+                  - funds_being_processed
+                  - trade_settling
+                  - closed
+                conversion_date_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for start of range for when buy currency was delivered.
+                conversion_date_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for end of range for when buy currency was delivered.
+                settlement_date_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for start of date range for when the sell_currency was debited.
+                settlement_date_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for end of date range for when the sell_currency was debited.
+                created_at_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for start of date range for when the conversion was created.
+                created_at_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for end of date range for when the conversion was created.
+                updated_at_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for start of date range for when the conversion was updated.
+                updated_at_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 Date/time for end of date range for when the conversion was updated.
+                unique_request_id:
+                  type: string
+                  description: Unique request ID of conversion.
+                  minLength: 1
+                  maxLength: 255
+                scope:
+                  type: string
+                  description: Specify which account level will be used - 'own' is the default.
+                  enum:
+                  - all
+                  - clients
+                  - own
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportRequest'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: description_is_too_long
+            category: description
+            message: description can not be longer than 255 character(s)
+            params: '{"maxlength": 255}'
+          - code: buy_currency_is_in_invalid_format
+            category: currency
+            message: sell_currency is not a valid ISO 4217 currency code
+            params: '{"type": "currency"}'
+          - code: sell_currency_is_in_invalid_format
+            category: currency
+            message: sell_currency is not a valid ISO 4217 currency code
+            params: '{"type": "currency"}'
+          - code: partner_sell_amount_to_type_is_wrong
+            category: currency
+            message: partner_sell_amount_to should be of numeric type
+            params: '{"type": "numeric" }'
+          - code: scope_not_in_range
+            category: currency
+            message: 'scope should be in range: own, all, clients'
+            params: '{"range": "own, all, clients"}'
+          - code: client_status_not_in_range
+            category: client
+            message: 'client_status should be in range: awaiting_funds, funds_sent, funds_arrived, trade_settled, closed,
+              awaiting_authorisation, funds_being_processed, trade_settling'
+            params: '{"range": "awaiting_funds, funds_sent, funds_arrived, trade_settled, closed, awaiting_authorisation,
+              funds_being_processed, trade_settling"}'
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateReportError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reports/payments/create:
+    post:
+      tags:
+      - Reporting
+      summary: Generate Payment Report
+      description: Returns a JSON structure with details of the payments report requested.
+      operationId: GeneratePaymentReport
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+                description:
+                  type: string
+                  description: Description that will be applied to report.
+                  minLength: 1
+                  maxLength: 255
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-letter ISO 4217 currency code.
+                  pattern: ^[A-Z]{3}$
+                amount_from:
+                  type: number
+                  description: Minimum payment amount to 2 decimal places.
+                  pattern: ^\d+(\.\d{1,3})?$
+                amount_to:
+                  type: number
+                  description: Maximum payment amount to 2 decimal places.
+                  pattern: ^\d+(\.\d{1,3})?$
+                bulk_upload_reference:
+                  type: string
+                  description: Reference to Bulk Upload.
+                  minLength: 1
+                  maxLength: 255
+                status:
+                  type: string
+                  description: Status of the payment.
+                payment_date_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for earliest payment date to include.
+                payment_date_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for latest payment date to include.
+                transferred_at_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for earliest payment transfer date.
+                transferred_at_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for latest payment transfer date.
+                created_at_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for earliest payment creation to include.
+                created_at_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for latest payment creation to include.
+                updated_at_from:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for earliest payment updated to include.
+                updated_at_to:
+                  type: string
+                  format: date
+                  description: ISO 8601 format date for latest payment updated to include.
+                beneficiary_id:
+                  type: string
+                  format: uuid
+                  description: ID of the beneficiary.
+                conversion_id:
+                  type: string
+                  format: uuid
+                  description: Conversion unique ID.
+                with_deleted:
+                  type: boolean
+                  description: Include deleted payments?
+                payment_group_id:
+                  type: string
+                  description: ID of the payment group.
+                  minLength: 1
+                  maxLength: 255
+                unique_request_id:
+                  type: string
+                  description: Unique request ID of payment.
+                  minLength: 1
+                  maxLength: 255
+                scope:
+                  type: string
+                  description: Specify which account level will be used - 'own' is the default value.
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportRequest'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: description_is_too_long
+            category: description
+            message: description can not be longer than 255 character(s)
+            params: '{"maxlength": 255}'
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: buy_currency is not a valid ISO 4217 currency code
+            params: '{"type": "currency"}'
+          - code: amount_from_type_is_wrong
+            category: amount_from
+            message: amount_from should be of numeric type
+            params: '{"type": "numeric"}'
+          - code: updated_at_to_is_in_invalid_format
+            category: update_at_to
+            message: updated_at_to should be in ISO 8601 format
+            params: '{"type": "datetime"}'
+          - code: conversion_id_is_not_valid_uuid
+            category: conversion_id
+            message: conversion_id should be in UUID format
+            params: '{"type": "datetime"}'
+          - code: with_deleted_type_is_wrong
+            category: with_deleted
+            message: with_deleted should be of boolean type
+            params: '{"type": "boolean"}'
+          - code: field_contains_invalid_characters
+            category: base
+            message: Field contains invalid characters
+            params: '{ ${field_name}: ${character_range} }'
+          - code: field_is_too_long
+            category: base
+            message: The information provided for this request exceeds our field length limits
+            params: '{ ${field_name}: ${max_field_length} }'
+          - code: request_contains_blocked_fields
+            category: base
+            message: This request contains fields that are not permitted for this route
+            params: '{ "blocked fields": [Fields that are not permitted for this route] }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateReportError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reports/report_requests/find:
+    get:
+      tags:
+      - Reporting
+      summary: Find Report Requests
+      description: Searches for report requests made. Returns a JSON structure with details of matching report requests.
+      operationId: FindReportRequests
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: short_reference
+        in: query
+        description: Your unique short reference.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 25
+      - name: description
+        in: query
+        description: Description that was provided during the report creation process.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      - name: created_at_from
+        in: query
+        description: Start date (for range), in ISO 8601 format, for when the reports were created.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: created_at_to
+        in: query
+        description: End date (for range), in ISO 8601 format, for when the reports were created.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: updated_at_from
+        in: query
+        description: Start date (for range), in ISO 8601 format, for when the reports were updated.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: updated_at_to
+        in: query
+        description: End date (for range), in ISO 8601 format, for when the reports were updated.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: expiration_date_from
+        in: query
+        description: Start date (for range), in ISO 8601 format, for when the report will be (was) expired.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: expiration_date_to
+        in: query
+        description: End date (for range), in ISO 8601 format, for when the report will be (was) expired.
+        required: false
+        schema:
+          type: string
+          format: date
+      - name: status
+        in: query
+        description: Status of the report.
+        required: false
+        schema:
+          type: string
+          enum:
+          - completed
+          - expired
+          - failed
+          - processing
+      - name: report_type
+        in: query
+        description: Type of reports, that we expect to receive in search results.
+        required: false
+        schema:
+          type: string
+          enum:
+          - beneficiary
+          - conversion
+          - payment
+          - transaction
+      - name: page
+        in: query
+        description: Page number.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: Any field name to change the sort order.
+        required: false
+        schema:
+          type: string
+          default: created_at
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      - name: scope
+        in: query
+        description: Specify which account level will be used; 'own' is the default value.
+        required: false
+        schema:
+          type: string
+          enum:
+          - all
+          - clients
+          - own
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  report_requests:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ReportRequest'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_not_found
+            category: id
+            message: Account was not found for this id
+            params: ''
+          - code: updated_at_to_is_in_invalid_format
+            category: updated_at_to
+            message: updated_at_to should be in ISO 8601 format
+            params: '{"type": "datetime"}'
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: processing, completed, expired, failed'
+            params: '{"range": "processing, completed, expired, failed"}'
+          - code: report_type_not_in_range
+            category: report_type
+            message: 'report_type should be in range: conversion, payment, beneficiary, transaction'
+            params: '{ "range": "conversion, payment, beneficiary, transaction" }'
+          - code: short_reference_is_too_long
+            category: short_reference
+            message: short_reference can not be longer than 25 character(s)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetReportRequestError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /reports/report_requests/{id}:
+    get:
+      tags:
+      - Reporting
+      summary: Retrieves a Report Request with the given ID
+      description: Searches for a report by ID. Returns a JSON structure with details of the specified report request.
+      operationId: RetrieveReportRequest
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: ID of the report.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportRequest'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_not_found
+            category: id
+            message: Account was not found for this id
+            params: ''
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetReportRequestError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /transactions/sender/{id}:
+    get:
+      tags:
+      - Sender
+      summary: Get Sender Details
+      description: Returns a JSON structure with details of the sender of funds.
+      operationId: GetSenderDetails
+      x-api-group: collect
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: The Related Entity UUID (related_entity_id) for the Transaction.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Sender'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: contact
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSenderError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Sender not found.
+          x-errors:
+          - code: sender_not_found
+            category: id
+            message: Sender not found
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /transactions/find:
+    get:
+      tags:
+      - Transactions
+      summary: Find Transactions
+      description: Search for transactions.
+      operationId: FindTransactions
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: currency
+        in: query
+        description: Three-letter ISO currency code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: amount
+        in: query
+        description: Amount the transaction is for.
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_from
+        in: query
+        description: Minimum amount
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_to
+        in: query
+        description: Maximum amount
+        required: false
+        schema:
+          type: string
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: action
+        in: query
+        description: The action that triggered the transaction.
+        required: false
+        schema:
+          type: string
+          enum:
+          - conversion
+          - conversion_deposit
+          - deposit_refund
+          - funding
+          - margin
+          - manual_transaction
+          - payment
+          - payment_failure
+          - payment_fee
+          - payment_unrelease
+          - transfer
+      - name: related_entity_type
+        in: query
+        description: The related entity that created the transaction.<br> For information, the related_entity_type for margin
+          transactions is <b>'margin_transaction'</b>. While it isn't possible to search directly by this value, margin transactions
+          can be filtered using the ‘action’ field and may be included in the response.
+        required: false
+        schema:
+          type: string
+          enum:
+          - conversion
+          - deposit
+          - inbound_funds
+          - payment
+          - transfer
+      - name: related_entity_id
+        in: query
+        description: UUID of the related entity.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: related_entity_short_reference
+        in: query
+        description: Short reference code.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 25
+      - name: status
+        in: query
+        description: Transaction status.
+        required: false
+        schema:
+          type: string
+          enum:
+          - completed
+          - deleted
+          - pending
+      - name: type
+        in: query
+        description: Whether the transaction debits or credits the account balance.
+        required: false
+        schema:
+          type: string
+          enum:
+          - credit
+          - debit
+      - name: settles_at_from
+        in: query
+        description: Earliest processing date. Any valid ISO 8601 format, e.g. "e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: settles_at_to
+        in: query
+        description: Latest processing date. Any valid ISO 8601 format, e.g. "e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: created_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: created_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: updated_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: updated_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: completed_at_from
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: completed_at_to
+        in: query
+        description: Any valid ISO 8601 format, e.g. "2023-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: beneficiary_id
+        in: query
+        description: Beneficiary UUID. Required if "related_entity_type" is "payment".
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: currency_pair
+        in: query
+        description: Concatenated string of the two currencies traded, e.g. "USDEUR". Required if "related_entity_type" is
+          "conversion".
+        required: false
+        schema:
+          type: string
+          pattern: ^[A-Z]{6}$
+      - name: scope
+        in: query
+        description: '"Own" account, "clients" sub-accounts, or "all" accounts.'
+        required: false
+        schema:
+          type: string
+          enum:
+          - all
+          - clients
+          - own
+          default: own
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: The field to sort by. Defaults to 'created_at' if not specified.<br><br> Please note that if you choose
+          to order by 'completed_at', it's important to populate the query parameter 'status' with the value 'completed' in
+          order to ensure that transactions are sequenced in the order they were processed. Without this, transactions that
+          completed within the same second may not be ordered correctly.
+        required: false
+        schema:
+          type: string
+          default: created_at
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort results in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transactions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Transaction'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: transaction_not_found
+            category: id
+            message: No Transaction found for 21b552e0-d97c-612d-2335-34203ab3f267
+            params: ''
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: completed, pending, deleted'
+            params: '{"range": "completed, pending, deleted" }'
+          - code: amount_type_is_wrong
+            category: amount
+            message: amount should be of numeric type
+            params: ''
+          - code: amount_from_type_is_wrong
+            category: amount_from
+            message: amount_from should be of numeric type
+            params: ''
+          - code: amount_to_type_is_wrong
+            category: amount_to
+            message: amount_to should be of numeric type
+            params: ''
+          - code: created_at_to_type_is_wrong
+            category: created_as_to
+            message: created_at_to should be of date type
+            params: '{"type": "date"}'
+          - code: completed_at_to_type_is_wrong
+            category: completed_at_to
+            message: completed_at_to should be of date type
+            params: '{"type": "date"}'
+          - code: related_entity_id_is_not_valid_uuid
+            category: related_entity
+            message: related_entity_id should be in UUID format
+            params: ''
+          - code: contact_not_found
+            category: on_behalf_of
+            message: Contact was not found for this id
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: related_entity_type_not_in_range
+            category: related_entity_type
+            message: 'related_entity_type should be in range: conversion, payment, inbound_funds, deposit, transfer'
+            params: '{ "range" => "conversion, payment, inbound_funds, deposit, transfer" }'
+          - code: action_not_in_range
+            category: action
+            message: 'action should be in range: funding, conversion, payment, payment_failure, manual_transaction, transfer,
+              conversion_deposit, deposit_refund, payment_unrelease, payment_fee, margin'
+            params: '{ "range" => "funding, conversion, payment, payment_failure, manual_transaction,  transfer, conversion_deposit,
+              deposit_refund, payment_unrelease, payment_fee, margin" }'
+          - code: scope_not_in_range
+            category: scope
+            message: 'scope should be in range: own, all, clients'
+            params: '{ "range" => "own, all, clients" }'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindTransactionsError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+  /transactions/{id}:
+    get:
+      tags:
+      - Transactions
+      summary: Get Transaction
+      description: Gets a transaction record.
+      operationId: GetTransaction
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Transaction UUID
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: transaction_not_found
+            category: id
+            message: No Transaction found for 38f7ca23-8090-403b-bc4a-eb1ba2ac9f29
+            params: '{"id": "38f7ca23-8090-403b-bc4a-eb1ba2ac9f29"}'
+          - code: id_is_not_valid_uuid
+            category: id
+            message: id should be in UUID format
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransactionError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /transfers/create:
+    post:
+      tags:
+      - Transfers
+      summary: Create Transfer
+      description: Transfers funds from one account to another. No currency conversion is performed, so the sending and receiving
+        accounts must hold money in the same currency.
+      operationId: CreateTransfer
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                source_account_id:
+                  type: string
+                  format: uuid
+                  description: Account UUID of the paying account.
+                destination_account_id:
+                  type: string
+                  format: uuid
+                  description: Account UUID of the receiving account.
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-letter ISO currency code.
+                  pattern: ^[A-Z]{3}$
+                amount:
+                  type: number
+                  description: Amount
+                  pattern: ^\d+(\.\d{1,3})?$
+                reason:
+                  type: string
+                  description: User-generated reason for transfer, freeform text.
+                  minLength: 1
+                  maxLength: 255
+                unique_request_id:
+                  type: string
+                  description: User-generated idempotency key. The value must be 100 characters or fewer.
+                  minLength: 1
+                  maxLength: 255
+              required:
+              - source_account_id
+              - destination_account_id
+              - currency
+              - amount
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_not_found
+            category: account_id
+            message: Account was not found for this id
+            params: ''
+          - code: amount_is_too_big
+            category: amount
+            message: Amount cannot be greater than 10000000000
+            params: ''
+          - code: amount_type_is_wrong
+            category: amount
+            message: Amount should be of numeric_greater_than_zero type
+            params: ''
+          - code: cash_workflow_unknown
+            category: account_id
+            message: Could not retrieve cash workflow for account {account_id}
+            params: ''
+          - code: cash_workflow_unknown
+            category: account_id
+            message: Could not retrieve cash workflow for account {account_id}
+            params: ''
+          - code: cross_hub_transfer_not_permitted
+            category: unique_request_id
+            message: The accounts would require a transfer between two hub banks which is not permitted
+            params: ''
+          - code: currency_is_in_invalid_format
+            category: currency
+            message: '{currency} currency is not a valid ISO 4217 currency code'
+            params: ''
+          - code: currency_is_not_supported
+            category: currency
+            message: '{currency} currency is restricted'
+            params: ''
+          - code: destination_account_disabled
+            category: null
+            message: The transfer was not created successfully because the destination account is disabled. Ensure that both
+              source and destination accounts are enabled before making a transfer.
+            params: ''
+          - code: destination_account_id_is_not_valid_uuid
+            category: account_id
+            message: destination_account_id should be in UUID format
+            params: ''
+          - code: destination_bank_account_verified_error
+            category: account_id
+            message: Destination bank account is not verified. Ensure that both source and destination bank accounts are verified
+              before making a transfer.
+            params: ''
+          - code: duplicate_unique_request_id
+            category: unique_request_id
+            message: The unique_request_id provided for this transfer has already been used, please provide a new one to successfully
+              submit this transfer
+            params: ''
+          - code: invalid_amount_format
+            category: amount
+            message: '{currency} does not support any decimal places'
+            params: ''
+          - code: invalid_amount_format
+            category: amount
+            message: '{currency} only supports up to 1 decimal place'
+            params: ''
+          - code: invalid_amount_format
+            category: amount
+            message: '{currency} only supports up to %d decimal places'
+            params: ''
+          - code: invalid_extra_parameters
+            category: invalid_extra_parameters
+            message: Invalid extra parameters:{parameter}
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: not_allowed_currency
+            category: currency
+            message: You cannot perform this operation in {currency} currency
+            params: ''
+          - code: reason_too_long
+            category: reason
+            message: Reason longer than 255 symbols
+            params: ''
+          - code: same_source_and_destination_accounts
+            category: account_id
+            message: Source and Destination accounts cannot be the same
+            params: ''
+          - code: source_account_disabled
+            category: account_id
+            message: The transfer was not created successfully because the source account is disabled. Ensure that both source
+              and destination accounts are enabled before making a transfer.
+            params: ''
+          - code: source_account_id_is_not_valid_uuid
+            category: source_account_id
+            message: source_account_id should be in UUID format
+            params: ''
+          - code: source_bank_account_verified_error
+            category: source_account_id
+            message: Source bank account is not verified. Ensure that both source and destination bank accounts are verified
+              before making a transfer.
+            params: ''
+          - code: transfer_not_permitted
+            category: account_id
+            message: The transfer is not permitted between the source and destination accounts defined.
+            params: ''
+          - code: unique_request_id_too_long
+            category: unique_request_id
+            message: The unique_request_id provided is longer than 100 characters, please provide a shorter one
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateTransferError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /transfers/{id}:
+    get:
+      tags:
+      - Transfers
+      summary: Get Transfer
+      description: Returns the money transfer record with the given ID.
+      operationId: GetTransfer
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: Transfer UUID, this was returned when the transfer was created.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: null
+            message: id should be in UUID format
+            params: ''
+          - code: invalid_extra_parameters
+            category: extra_parameter
+            message: Invalid extra parameters:'{parameter}'
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: transfer_not_found
+            category: null
+            message: Transfer was not found for this ID
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTransferError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /transfers/find:
+    get:
+      tags:
+      - Transfers
+      summary: Find Transfers
+      description: Searches for transfer records that meet the given criteria.
+      operationId: FindTransfers
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: on_behalf_of
+        in: query
+        description: A contact UUID for the sub-account you're acting on behalf of.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: short_reference
+        in: query
+        description: Short reference code.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 25
+      - name: source_account_id
+        in: query
+        description: Account UUID of the paying account.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: destination_account_id
+        in: query
+        description: Account UUID of the receiving account.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: status
+        in: query
+        description: Transfer status
+        required: false
+        schema:
+          type: string
+          enum:
+          - cancelled
+          - completed
+          - pending
+      - name: currency
+        in: query
+        description: Three-letter ISO currency code.
+        required: false
+        schema:
+          type: string
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+      - name: amount_from
+        in: query
+        description: Minimum amount
+        required: false
+        schema:
+          type: number
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: amount_to
+        in: query
+        description: Maximum amount
+        required: false
+        schema:
+          type: number
+          pattern: ^\d+(\.\d{1,3})?$
+      - name: created_at_from
+        in: query
+        description: Any valid ISO 8601 format, no older than two years e.g. "2024-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: created_at_to
+        in: query
+        description: Any valid ISO 8601 format, no older than two years e.g. "2024-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: updated_at_from
+        in: query
+        description: Any valid ISO 8601 format, no older than two years e.g. "2024-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: updated_at_to
+        in: query
+        description: Any valid ISO 8601 format, no older than two years e.g. "2024-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: completed_at_from
+        in: query
+        description: Any valid ISO 8601 format, no older than two years e.g. "2024-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: completed_at_to
+        in: query
+        description: Any valid ISO 8601 format, no older than two years e.g. "2024-12-31T23:59:59Z".
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: creator_contact_id
+        in: query
+        description: Contact UUID of transfer instructor.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: creator_account_id
+        in: query
+        description: Account UUID of transfer instructor.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: page
+        in: query
+        description: Page number
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: per_page
+        in: query
+        description: Number of results per page.
+        required: false
+        schema:
+          type: integer
+          pattern: ^\d+$
+      - name: order
+        in: query
+        description: The field name to sort by - "created_at", "updated_at" or "completed_at". Defaults to "created_at" if
+          not specified..<br>
+        required: false
+        schema:
+          type: string
+          enum:
+          - created_at
+          - updated_at
+          - completed_at
+          default: created_at
+          minLength: 1
+          maxLength: 255
+      - name: order_asc_desc
+        in: query
+        description: Sort records in ascending or descending order.
+        required: false
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+      - name: unique_request_id
+        in: query
+        description: User-generated idempotency key.
+        required: false
+        schema:
+          type: string
+          minLength: 1
+          maxLength: 255
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transfers:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Transfer'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: amount_from_type_is_wrong
+            category: amount_from
+            message: amount_from should be of numeric type
+            params: ''
+          - code: amount_to_type_is_wrong
+            category: amount_to
+            message: amount_to should be of numeric type
+            params: ''
+          - code: completed_at_from_is_in_invalid_format
+            category: completed_at_from
+            message: completed_at_from should be in ISO 8601 format
+            params: ''
+          - code: completed_at_from_is_too_old
+            category: completed_at_from
+            message: completed_at_from is set to a date too far back
+            params: ''
+          - code: completed_at_to_is_in_invalid_format
+            category: completed_at_to
+            message: completed_at_from should be in ISO 8601 format
+            params: ''
+          - code: created_at_from_is_in_invalid_format
+            category: created_at_from
+            message: created_at_from should be in ISO 8601 format
+            params: ''
+          - code: created_at_from_is_too_old
+            category: created_at_from
+            message: created_at_from is set to a date too far back
+            params: ''
+          - code: created_at_to_is_in_invalid_format
+            category: created_at_to
+            message: created_at_from should be in ISO 8601 format
+            params: ''
+          - code: destination_account_id_is_not_valid_uuid
+            category: destination_account_id
+            message: destination_account_id should be in UUID format
+            params: ''
+          - code: invalid_extra_parameters
+            category: extra_parameter
+            message: Invalid extra parameters:'{parameter}'
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: page_is_too_small
+            category: page
+            message: page can not be smaller than 1
+            params: ''
+          - code: page_type_is_wrong
+            category: page
+            message: page should be of integer type
+            params: ''
+          - code: per_page_is_too_big
+            category: per_page
+            message: per_page can not be bigger than %i
+            params: ''
+          - code: per_page_is_too_small
+            category: per_page
+            message: per_page can not be smaller than 1
+            params: ''
+          - code: per_page_type_is_wrong
+            category: per_page
+            message: per_page should be of integer type
+            params: ''
+          - code: source_account_id_is_not_valid_uuid
+            category: source_account_id
+            message: source_account_id should be in UUID format
+            params: ''
+          - code: status_not_in_range
+            category: status
+            message: 'status should be in range: pending, completed, cancelled'
+            params: ''
+          - code: updated_at_from_is_in_invalid_format
+            category: updated_at_from
+            message: updated_at_from should be in ISO 8601 format
+            params: ''
+          - code: updated_at_from_is_too_old
+            category: updated_at_from
+            message: updated_at_from is set to a date too far back
+            params: ''
+          - code: updated_at_to_is_in_invalid_format
+            category: updated_at_to
+            message: updated_at_from should be in ISO 8601 format
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FindTransfersError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /transfers/{id}/cancel:
+    post:
+      tags:
+      - Transfers
+      summary: Cancel Transfer
+      description: Requests that a transfer be cancelled.
+      operationId: CancelTransfer
+      x-api-group: pay
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: id
+        in: path
+        description: ID of the transfer to be cancelled.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transfer'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_is_not_valid_uuid
+            category: account_id
+            message: id should be in UUID format
+            params: ''
+          - code: invalid_extra_parameters
+            category: invalid_extra_parameters
+            message: Invalid extra parameters:'{parameter}'
+            params: '{ "parameters" => "extra_parameter" }'
+          - code: transfer_cannot_be_cancelled
+            category: short_reference
+            message: Transfer {short_reference} cannot be cancelled
+            params: ''
+          - code: transfer_is_already_cancelled
+            category: short_reference
+            message: Transfer {short_reference} is already cancelled
+            params: ''
+          - code: transfer_is_already_completed
+            category: short_reference
+            message: Transfer {short_reference} cannot be cancelled since it is already completed
+            params: ''
+          - code: transfer_not_found
+            category: id
+            message: Transfer was not found for this ID
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelTransferError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: You do not have permission 'transfer_write' to perform this operation
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /withdrawal_accounts/find:
+    get:
+      tags:
+      - Withdrawal Accounts
+      summary: Find Withdrawal Account
+      description: Lists all withdrawal accounts assigned to an account.
+      operationId: FindWithdrawalAccount
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: account_id
+        in: query
+        description: The UUID of a sub-account you want to see the withdrawal accounts for. If omitted the withdrawal accounts
+          for the house account and all sub-accounts are returned.
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  withdrawal_accounts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/WithdrawalAccount'
+                  pagination:
+                    $ref: '#/components/schemas/Pagination'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: account_id_is_not_valid_uuid
+            category: account_id
+            message: account_id should be in UUID format
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetWithdrawalAccountError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: permission_denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: account_not_found
+            message: Account was not found for this id
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /withdrawal_accounts/{withdrawal_account_id}/pull_funds:
+    post:
+      tags:
+      - Withdrawal Accounts
+      summary: Pull Funds From Withdrawal Account
+      description: Submits an ACH pull request from a specific withdrawal account. The funds will be pulled into the account
+        the specified withdrawal account is related to.
+      operationId: PullFundsFromWithdrawalAccount
+      x-api-group: manage
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: withdrawal_account_id
+        in: path
+        description: The withdrawal account ID you want to pull the funds from. The funds will be pulled into the account
+          ID related to this withdrawal account.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                reference:
+                  type: string
+                  description: The reference you want on the statement.
+                  minLength: 1
+                  maxLength: 255
+                amount:
+                  type: number
+                  description: The amount of funds to pull in USD.
+                  pattern: ^\d+(\.\d{1,3})?$
+              required:
+              - reference
+              - amount
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WithdrawalPullFundsRequestDetails'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: withdrawal_account_not_found
+            category: id
+            message: No withdrawal account found for this account
+            params: ''
+          - code: withdrawal_account_id_is_not_valid_uuid
+            category: id
+            message: withdrawal_account_id should be in UUID format
+            params: ''
+          - code: reference_is_required
+            category: reference
+            message: reference is required
+            params: ''
+          - code: reference_invalid
+            category: reference
+            message: Only characters, digits, spaces, '_' and '-' allowed
+            params: ''
+          - code: reference_too_long
+            category: reference
+            message: Reference cannot be longer than 10 characters
+            params: ''
+          - code: amount_is_required
+            category: amount
+            message: amount is required
+            params: ''
+          - code: amount_is_in_invalid_format
+            category: amount
+            message: amount should be of numeric type with 2 dp
+            params: '{ "type" => "numeric_with_precision", "precision" => 2 }'
+          - code: amount_not_positive
+            category: amount
+            message: Amount should be positive
+            params: ''
+          - code: amount_not_allowed
+            category: amount
+            message: Amount should be up to 100000 limit
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WithdrawalPullFundsRequestError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: Permission denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: account_not_found
+            message: Account was not found for this id
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /demo/funding/create:
+    post:
+      tags:
+      - Demo
+      summary: Emulate inbound funds
+      description: Triggers a production-like flow for processing funds, topping up CM balance or rejecting the transaction
+        without topping up CM balance. This resource is only available in the Currencycloud Demo environment; it is not implemented
+        in the Production environment.
+      operationId: SimulateFunding
+      x-api-group: collect
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  format: uuid
+                  description: Unique value in UUID format, user-generated with each request.
+                sender_name:
+                  type: string
+                  description: Sender's name.
+                  default: Test sender
+                  minLength: 1
+                  maxLength: 255
+                sender_address:
+                  type: string
+                  description: Sender's address.
+                  minLength: 1
+                  maxLength: 255
+                sender_country:
+                  type: string
+                  format: iso3166-1-alpha-2
+                  description: Two character ISO sender country code.
+                  pattern: ^[A-Z]{2}$
+                sender_reference:
+                  type: string
+                  description: Sender reference.
+                  minLength: 1
+                  maxLength: 255
+                sender_account_number:
+                  type: string
+                  description: Sender account number.
+                  minLength: 1
+                  maxLength: 255
+                sender_routing_code:
+                  type: string
+                  description: Sender routing code.
+                  minLength: 1
+                  maxLength: 255
+                receiver_account_number:
+                  type: string
+                  description: A client's virtual account number or its sub-account (as seen in Find Funding Accounts).
+                  minLength: 1
+                  maxLength: 255
+                receiver_routing_code:
+                  type: string
+                  description: A client's virtual account routing code or its sub-account (as seen in Find Funding Accounts).
+                  minLength: 1
+                  maxLength: 255
+                amount:
+                  type: number
+                  description: Amount of the emulated transaction.
+                  pattern: ^\d+(\.\d{1,3})?$
+                currency:
+                  type: string
+                  format: iso-4217
+                  description: Three-digit currency code.
+                  pattern: ^[A-Z]{3}$
+                action:
+                  type: string
+                  description: Allows you to trigger approval or rejection behaviour.
+                  enum:
+                  - approve
+                  - reject
+                  default: approve
+                on_behalf_of:
+                  type: string
+                  format: uuid
+                  description: A contact UUID for the sub-account you're acting on behalf of.
+              required:
+              - id
+              - receiver_account_number
+              - amount
+              - currency
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulateFunding'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: id_cant_be_blank
+            category: id
+            message: ID can't be blank
+            params: ''
+          - code: id_has_invalid_format
+            category: id
+            message: ID should be in UUID format
+            params: ''
+          - code: receiver_account_number_cant_be_blank
+            category: receiver_account_number
+            message: Receiver account number can't be blank
+            params: ''
+          - code: receiver_account_number_not_found
+            category: receiver_account_number
+            message: Receiver account number not found
+            params: ''
+          - code: sender_country_is_invalid
+            category: sender_country
+            message: Sender country is invalid
+            params: ''
+          - code: sender_country_has_invalid_format
+            category: sender_country
+            message: Sender country is not a valid ISO 3166 country code
+            params: ''
+          - code: amount_cant_be_blank
+            category: amount
+            message: Amount can't be blank
+            params: ''
+          - code: amount_must_be_greater_than_0
+            category: amount
+            message: Amount must be greater than 0
+            params: ''
+          - code: amount_must_be_less_than_1000000000000
+            category: amount
+            message: Amount must be less than 1 000 000 000 000
+            params: ''
+          - code: amount_is_invalid
+            category: amount
+            message: Amount should be numeric with 2 decimal points separated by '.'
+            params: ''
+          - code: action_is_invalid
+            category: action
+            message: 'Action is invalid, should be in range: approve, reject'
+            params: ''
+          - code: currency_cant_be_blank
+            category: currency
+            message: Currency can't be blank
+            params: ''
+          - code: currency_is_invalid
+            category: currency
+            message: Currency is invalid
+            params: ''
+          - code: currency_has_invalid_format
+            category: currency
+            message: Currency is not a valid ISO 4217 currency code
+            params: ''
+          - code: currency_not_supported_by_account
+            category: currency
+            message: Currency not supported by account
+            params: ''
+          - code: on_behalf_of_is_not_valid_uuid
+            category: on_behalf_of
+            message: on_behalf_of should be in UUID format
+            params: ''
+          - code: on_behalf_of_self
+            category: on_behalf_of
+            message: You cannot act on behalf of your own Contact
+            params: ''
+          - code: id_has_already_been_taken
+            category: id
+            message: ID was already used in a previous request
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateSimulateFundingError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '401':
+          description: Unauthorized.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: username
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '403':
+          description: Forbidden.
+          x-errors:
+          - code: permission_denied
+            message: permission_denied
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '429':
+          description: Too many requests.
+          x-errors:
+          - code: too_many_requests
+            category: base
+            message: Too many requests have been made to the api. Please refer to the Developer Center for more information
+            params: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitError'
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '500':
+          description: Internal server error
+          x-errors:
+          - code: internal_server_error
+            category: base
+            message: Internal server error
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+          - code: service_unavailable
+            category: base
+            message: Service is temporarily unavailable
+            params: ''
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+  /collections_screening/{transactionId}/complete:
+    put:
+      tags:
+      - Transaction Approval
+      summary: Accept or Reject Inbound Transaction
+      description: '
+
+        Allows you to accept or reject an inbound transaction before the funds are credited to the beneficiary’s account.'
+      operationId: CompleteCollectionsScreening
+      x-api-group: collect
+      parameters:
+      - name: X-Auth-Token
+        in: header
+        description: Authentication token.
+        required: true
+        schema:
+          type: string
+          minLength: 32
+      - name: transactionId
+        in: path
+        description: The related_entity_id from the Cash Manager notification.
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                accepted:
+                  type: boolean
+                  description: Should the transaction be accepted - true or false.
+                  enum:
+                  - true
+                  - false
+                reason:
+                  type: string
+                  description: 'Reason for acceptance or rejection. If "accepted" is true, the value should be "accepted".
+                    If "accepted" is false, the value should be one of the other values.
+
+                    '
+                  enum:
+                  - accepted
+                  - sanctioned_match
+                  - unsupported_currency
+                  - insufficient_transaction_information
+                  - suspected_fraud
+                  - internal_watchlist_match
+                  - suspected_money_laundering_activity
+                  minLength: 1
+                  maxLength: 255
+              required:
+              - accepted
+              - reason
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  transaction_id:
+                    description: The transaction UUID
+                    type: string
+                    example: bdcca5e6-32fe-45f6-9476-6f8f518e6270
+                  account_id:
+                    type: string
+                    description: Account UUID
+                    example: 7a116d7d-6310-40ae-8d54-0ffbe41dc1c9
+                  house_account_id:
+                    description: House Account UUID
+                    type: string
+                    example: 7a116d7d-6310-40ae-8d54-0ffbe41dc1c9
+                  result:
+                    type: object
+                    properties:
+                      reason:
+                        description: The reason why the transaction was accepted or rejected.
+                        type: string
+                        example: Accepted
+                      accepted:
+                        description: Was the transaction accepted? True or false.
+                        type: boolean
+                        example: true
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '400':
+          description: Client error.
+          x-errors:
+          - code: screening_already_expired
+            category: base
+            message: Screening is already expired.
+            params: ''
+          - code: transaction_id_is_not_valid_uuid
+            category: base
+            message: transaction_id should be in UUID format
+            params: ''
+          - code: accepted_type_is_wrong
+            category: base
+            message: accepted should be of boolean type
+            params: ''
+          - code: invalid_request
+            category: base
+            message: 'Invalid reason provided, expected one of: sanctioned_match, unsupported_currency, insufficient_transaction_information,
+              suspected_fraud, internal_watchlist_match, suspected_money_laundering_activity'
+            params: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error_code:
+                    type: string
+                    example: '400'
+                  error_messages:
+                    type: object
+                    properties:
+                      base:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            example: '400'
+                          message:
+                            type: string
+                            example: Screening is already expired.
+                          params:
+                            type: object
+                            example: {}
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request
+              schema:
+                type: string
+        '401':
+          description: Authentication failed.
+          x-errors:
+          - code: invalid_supplied_credentials
+            category: base
+            message: Authentication failed with the supplied credentials
+            params: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error_code:
+                    type: string
+                    example: auth_failed
+                  error_messages:
+                    type: object
+                    properties:
+                      username:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            code:
+                              type: string
+                              example: invalid_supplied_credentials
+                            message:
+                              type: string
+                              example: Authentication failed with the supplied credentials
+                            params:
+                              type: object
+                              example: {}
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        '404':
+          description: Resource not found.
+          x-errors:
+          - code: resource_not_found
+            category: base
+            message: Unable to find the resource.
+            params: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error_code:
+                    type: string
+                    example: '404'
+                  error_messages:
+                    type: object
+                    properties:
+                      base:
+                        type: object
+                        properties:
+                          code:
+                            type: string
+                            example: '404'
+                          message:
+                            type: string
+                            example: Unable to find the resource.
+                          params:
+                            type: object
+                            example: {}
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              description: A unique reference for the request.
+              schema:
+                type: string
+components:
+  schemas:
+    AcceptTermsResponse:
+      type: object
+      description: Accept Terms of Use response.
+      properties:
+        acceptance_id:
+          type: string
+          description: The ID of the acceptance.
+        accepted_at:
+          type: string
+          format: date-time
+          description: The date and time that the Terms of Use were accepted.
+    Account:
+      type: object
+      description: Account.
+      properties:
+        id:
+          type: string
+          description: Account ID
+        account_name:
+          type: string
+          description: Account name
+        brand:
+          type: string
+          description: The value of this field is used for white labeling the Currencycloud user interface.
+        your_reference:
+          type: string
+          description: User-generated reference code.
+        status:
+          type: string
+          enum:
+          - disabled
+          - enabled
+          - enabled_no_trading
+          description: Account status
+        street:
+          type: string
+          description: First line of address.
+        city:
+          type: string
+          description: City
+        state_or_province:
+          type: string
+          description: State or province two-letter ISO 3166 code. Only applicable to some countries.
+        country:
+          type: string
+          description: Two-letter ISO country code.
+        postal_code:
+          type: string
+          description: Postal code
+        spread_table:
+          type: string
+          description: The name of the spread table assigned to the account.
+        legal_entity_type:
+          type: string
+          description: The type of entity - individual or company.
+        legal_entity_sub_type:
+          type: string
+          enum:
+          - sole_trader
+          - limited_liability_company
+          - public_limited_company
+          - limited_liability_partnership
+          - unincorporated_partnership
+          - unregistered_charity
+          - registered_charity
+          - trust
+          - company_with_nominee_shareholders_or_shares_in_bearer_form
+          - scottish_limited_partnership
+          - other
+        created_at:
+          type: string
+          description: The date/time the account was created.
+          format: date-time
+        updated_at:
+          type: string
+          description: The date/time the account was last updated.
+          format: date-time
+        identification_type:
+          type: string
+          description: The legal document that verifies the identity of the account owner, e.g. passport.
+          enum:
+          - citizenship_papers
+          - credential_de_elector
+          - drivers_license
+          - drivers_license_canadian
+          - employer_identification_number
+          - existing_credit_card_details
+          - green_card
+          - incorporation_number
+          - matricula_consular
+          - national_id
+          - none
+          - others
+          - passport
+          - registro_federal_de_contribuyentes
+          - social_insurance_number
+          - social_security_number
+          - visa
+        identification_value:
+          type: string
+          description: The unique reference code for the identification document, e.g. passport number.
+        identification_issuer:
+          type: string
+          description: ISO-3116 country code for the issuer of the identification document
+        identification_expiration:
+          type: string
+          format: date
+          description: Date of expiration for the identification document
+        short_reference:
+          description: The account's reference number.
+          type: string
+        api_trading:
+          description: Is trading via the Currencycloud API enabled?
+          type: boolean
+        online_trading:
+          description: Is trading via Currencycloud Direct enabled?
+          type: boolean
+        phone_trading:
+          description: Is trading via phone enabled?
+          type: boolean
+        process_third_party_funds:
+          description: Is the account enabled for third party funds?
+          type: boolean
+        settlement_type:
+          description: The settlement type - bulk or net.
+          enum:
+          - bulk
+          - net
+          type: string
+        terms_and_conditions_accepted:
+          description: Have the terms and conditions been accepted?
+          type: boolean
+        agent_or_reliance:
+          description: True for clients using Currencycloud’s regulatory coverage, false otherwise.
+          type: boolean
+        bank_account_verified:
+          description: Has the bank account been verified?
+          type: string
+          enum:
+          - 'yes'
+          - 'no'
+          - 'not required'
+      example:
+        id: B7DE235A-FF5D-4252-83C2-06A605267FEA
+        account_name: Company PLC
+        brand: currencycloud
+        your_reference: 0012345564ABC
+        status: enabled
+        street: 1 London Road
+        city: London
+        state_or_province: ''
+        country: GB
+        postal_code: AB12 CD1
+        spread_table: flat_0.5_percent
+        legal_entity_type: company
+        legal_entity_sub_type: limited_liability_company
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+        identification_type: green_card
+        identification_value: 123456789
+        identification_issuer: US
+        identification_expiration: '2020-12-31'
+        short_reference: 110104-00004
+        api_trading: true
+        online_trading: true
+        phone_trading: true
+        process_third_party_funds: false
+        settlement_type: bulk
+        terms_and_conditions_accepted: true
+        agent_or_reliance: true
+        bank_account_verified: false
+    AccountComplianceSettings:
+      type: object
+      description: Account compliance settings.
+      properties:
+        account_id:
+          type: string
+          description: Account UUID.
+        industry_type:
+          type: string
+          description: String describing the accounts main industry. See merchant category codes for examples
+        country_of_incorporation:
+          type: string
+          description: 'Two-letter ISO-3166 Country Code indicating the country the account is incorporated in. Should only
+            be present for ''legal_entity_type: company'' accounts'
+        date_of_incorporation:
+          type: string
+          format: date
+          description: 'The date of the accounts incorporation. Should only be present for ''legal_entity_type: company''
+            accounts'
+        business_website_url:
+          type: string
+          description: A fully qualified URL (including scheme) indicating a marketplace homepage, a link to a government
+            page concerning the company or the literal string 'no_website_available'.
+        expected_transaction_countries:
+          type: array
+          description: Array of ISO-3166 country codes that these accounts will transact to/from.
+          items:
+            type: string
+        expected_transaction_currencies:
+          type: array
+          description: Array of ISO-4217 currency codes that these accounts will transact with. Limited to a single item.
+          items:
+            type: string
+        expected_monthly_activity_volume:
+          type: integer
+          description: The number of transactions this account is expected to conduct.
+        expected_monthly_activity_value:
+          type: number
+          description: The value of transactions this account is expected to conduct. The currency for this is the single
+            item in 'expected_transaction_currencies'.
+        tax_identification:
+          type: string
+          description: 'A tax identification value for companies in the United States or Australia; determined by ''accounts.country''.
+            Should only be present for ''legal_entity_type: company'' accounts.'
+        national_identification:
+          type: string
+          description: 'A National identification value for an individual in the United States; determined by ''accounts.country''.
+            Should only be present for ''legal_entity_type: individual'' accounts.'
+        country_of_citizenship:
+          type: string
+          description: 'An ISO-3166 country code for an individuals citizenship. Should only be present for ''legal_entity_type:
+            individual'' accounts.'
+        trading_address_street:
+          type: string
+          description: 'The street address of the companies trading location. Should only be present for ''legal_entity_type:
+            company'' accounts.'
+        trading_address_city:
+          type: string
+          description: 'The city of the companies trading location. Should only be present for ''legal_entity_type: company''
+            accounts.'
+        trading_address_state:
+          type: string
+          description: 'The state of the companies trading location. Should only be present for ''legal_entity_type: company''
+            accounts.'
+        trading_address_postalcode:
+          type: string
+          description: 'The postal code of the companies trading location. Should only be present for ''legal_entity_type:
+            company'' accounts.'
+        trading_address_country:
+          type: string
+          description: 'The ISO-3166 country code of the companies trading location. Should only be present for ''legal_entity_type:
+            company'' accounts.'
+        customer_risk:
+          description: The risk classification for this account's behaviour.
+          type: string
+          enum:
+          - LOW
+          - MEDIUM
+          - HIGH
+      example:
+        account_id: B7DE235A-FF5D-4252-83C2-06A605267FEA
+        industry_type: Telecom Services
+        country_of_incorporation: US
+        date_of_incorporation: 2020-01-30
+        business_website_url: https://currencycloud.com
+        expected_transaction_countries:
+        - US
+        - GB
+        expected_transaction_currencies:
+        - USD
+        expected_monthly_activity_volume: 10
+        expected_monthly_activity_value: 30.0
+        tax_identification: some-tax-id
+        national_identification: some-national-id
+        country_of_citizenship: US
+        trading_address_street: some-street
+        trading_address_city: some-city
+        trading_address_state: NY
+        trading_address_postalcode: 90210
+        trading_address_country: US
+        customer_risk: LOW
+    AccountPaymentChargesSetting:
+      type: object
+      description: Account Payment Charges Setting.
+      properties:
+        charge_settings_id:
+          description: Unique ID
+          type: string
+        account_id:
+          description: Account ID
+          type: string
+        charge_type:
+          description: The charge type - shared or ours.
+          enum:
+          - ours
+          - shared
+          type: string
+        enabled:
+          description: Is this charge type enabled for this account?
+          type: boolean
+        default:
+          description: Is this the default charge type for this account?
+          type: boolean
+      example:
+        charge_settings_id: 2b7db581-a810-0132-a8c2-10b11cb33cfc
+        account_id: 2b6db571-a810-0144-a9b2-10a22cb33cf9
+        charge_type: shared
+        enabled: true
+        default: true
+    AuthenticationToken:
+      type: object
+      description: Authentication token
+      properties:
+        auth_token:
+          type: string
+          description: Currently a randomly-generated 32-digit authentication token. Clients must store this securely and
+            destroy it when it is no longer needed.
+      example:
+        auth_token: 043cc6069f5e32757647641460d1d5ed
+    AvailableCurrencies:
+      type: object
+      description: Available currencies
+      properties:
+        code:
+          description: Three-letter ISO currency code.
+          type: string
+        decimal_places:
+          description: The number of decimal places used by the currency.
+          type: integer
+        name:
+          description: The name of the currency.
+          type: string
+        online_trading:
+          description: Can the currency be traded online?
+          type: boolean
+          enum:
+          - true
+          - false
+        can_buy:
+          description: Can the currency be bought?
+          type: boolean
+          enum:
+          - true
+          - false
+        can_sell:
+          description: Can the currency be sold?
+          type: boolean
+          enum:
+          - true
+          - false
+      example:
+        code: AED
+        decimal_places: 2
+        name: United Arab Emirates Dirham
+        online_trading: true
+        can_buy: true
+        can_sell: true
+    Balance:
+      type: object
+      description: Balance.
+      properties:
+        id:
+          type: string
+          description: Balance UUID
+          format: UUID
+        account_id:
+          type: string
+          description: Account UUID
+          format: UUID
+        currency:
+          type: string
+          description: Three-letter ISO currency code for the currency the amount is shown in.
+        amount:
+          type: string
+          description: The balance amount.
+        created_at:
+          type: string
+          format: date-time
+          description: Date/time the record was created.
+        updated_at:
+          type: string
+          format: date-time
+          description: Date/time the record was last updated.
+      example:
+        id: 18230F1D-648A-406A-AD1F-A09CBC02E9E9
+        account_id: TcC
+        currency: USD
+        amount: '1000.00'
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+    BankDetails:
+      type: object
+      description: Bank Details
+      required:
+      - identifier_type
+      - identifier_value
+      additionalProperties: false
+      properties:
+        identifier_type:
+          type: string
+          description: The type of identifier used to identify the account (e.g. IBAN).
+        identifier_value:
+          type: string
+          description: The value of the identifier of the account in the format of the identifier_type (e.g. IBAN code).
+        account_number:
+          type: string
+          description: Account number
+        bic_swift:
+          type: string
+          description: BIC/Swift code.
+        bank_name:
+          type: string
+          description: Bank name
+        bank_branch:
+          type: string
+          description: Bank branch
+        bank_address:
+          type: string
+          description: Bank address
+        bank_city:
+          type: string
+          description: City of the bank.
+        bank_state:
+          type: string
+          description: State the bank is situated in. Available in all countries using states.
+        bank_post_code:
+          type: string
+          description: The bank's post code or the zip code for USA banks.
+        bank_country:
+          type: string
+          description: Full country name.
+        bank_country_ISO:
+          type: string
+          description: Two-letter ISO country code.
+        currency:
+          type: string
+          description: Three-letter ISO currency code.
+      example:
+        identifier_type: iban
+        identifier_value: FR7530002002460000012345X12
+        account_number: FR7530002002460000012345X12
+        bic_swift: CRLYFRPPXXX
+        bank_name: CREDIT LYONNAIS
+        bank_branch: AG STALINGRAD
+        bank_address: 212 BOULEVARD DE LA VILLETTE
+        bank_city: PARIS
+        bank_state: PARIS
+        bank_post_code: 75019
+        bank_country: FRANCE
+        bank_country_ISO: FR
+        currency: null
+    Beneficiary:
+      type: object
+      description: Beneficiary
+      properties:
+        id:
+          type: string
+          description: Beneficiary UUID
+        bank_account_holder_name:
+          type: string
+          description: Bank account holder's name.
+        name:
+          type: string
+          description: Beneficiary's name
+        email:
+          type: string
+          description: Beneficiary's email address
+        payment_types:
+          type: array
+          items:
+            type: string
+            description: The payment type - regular (local) or priority (Swift).
+            enum:
+            - priority
+            - regular
+        beneficiary_address:
+          type: array
+          items:
+            type: string
+            description: Line of address.
+        beneficiary_country:
+          type: string
+          description: Two-letter ISO country code.
+        beneficiary_entity_type:
+          type: string
+          description: Beneficiary legal entity type - company or individual.
+          enum:
+          - company
+          - individual
+        beneficiary_company_name:
+          type: string
+          description: For companies
+        beneficiary_first_name:
+          type: string
+          description: For individuals
+        beneficiary_last_name:
+          type: string
+          description: For individuals
+        beneficiary_city:
+          type: string
+          description: City
+        beneficiary_postcode:
+          type: string
+          description: Postal code
+        beneficiary_state_or_province:
+          type: string
+          description: State or province.
+        beneficiary_date_of_birth:
+          type: string
+          description: For companies, this is the foundation date of the company. For individuals, it is their date of birth.
+        beneficiary_identification_type:
+          type: string
+          description: A legal document that verifies the identity of the beneficiary.
+        beneficiary_identification_value:
+          type: string
+          description: A unique reference code for the identification document, such as a passport number.
+        bank_country:
+          type: string
+          description: Two-letter ISO code for the country in which the beneficiary's bank account is held.
+        bank_name:
+          type: string
+          description: Bank name
+        bank_account_type:
+          type: string
+          description: Bank account type.
+          enum:
+          - checking
+          - savings
+        currency:
+          type: string
+          description: Currency in which money is held in the beneficiary's bank account. Three-digit currency code.
+        account_number:
+          type: string
+          description: Bank account number.
+        routing_code_type_1:
+          type: string
+          description: Local payment routing system.
+        routing_code_value_1:
+          type: string
+          description: Value for "routing_code_type_1".
+        routing_code_type_2:
+          type: string
+          description: Local payment routing system.
+        routing_code_value_2:
+          type: string
+          description: Value for "routing_code_type_2".
+        bic_swift:
+          type: string
+          description: BIC/Swift code
+        iban:
+          type: string
+          description: IBAN code
+        default_beneficiary:
+          type: string
+          description: Payments are made automatically to default beneficiaries when a beneficiary is not specified.
+          enum:
+          - 'true'
+          - 'false'
+        creator_contact_id:
+          type: string
+          description: Contact UUID of beneficiary creator.
+        bank_address:
+          type: array
+          items:
+            type: string
+            description: Line of address.
+        created_at:
+          type: string
+          description: Date the beneficiary record was created.
+          format: date-time
+        updated_at:
+          type: string
+          description: Date the beneficiary record was last updated.
+          format: date-time
+        beneficiary_external_reference:
+          type: string
+          description: Beneficiary external reference.
+        business_nature:
+          type: string
+          description: Beneficiary nature of business.
+        company_website:
+          type: string
+          description: Beneficiary company website.
+      example:
+        id: a6000ce9-46b8-49a7-9f5b-325ed3f047c2
+        bank_account_holder_name: Company PLC
+        name: Sample name
+        email: ''
+        payment_types:
+        - regular
+        beneficiary_address:
+        - 1 My Road
+        - London
+        beneficiary_country: AU
+        beneficiary_entity_type: company
+        beneficiary_company_name: Sample Company Name
+        beneficiary_first_name: ''
+        beneficiary_last_name: ''
+        beneficiary_city: ''
+        beneficiary_postcode: ''
+        beneficiary_state_or_province: ''
+        beneficiary_date_of_birth: ''
+        beneficiary_identification_type: none
+        beneficiary_identification_value: ''
+        bank_country: AU
+        bank_name: Sample Bank Name
+        bank_account_type: checking
+        currency: AUD
+        account_number: '123456783'
+        routing_code_type_1: bsb_code
+        routing_code_value_1: '123456'
+        routing_code_type_2: ''
+        routing_code_value_2: ''
+        bic_swift: ''
+        iban: ''
+        default_beneficiary: 'false'
+        creator_contact_id: 58e78791-e0e5-012c-2dee-001e52f3c730
+        bank_address:
+        - Line 1
+        - Line 2
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+        beneficiary_external_reference: B-5847789
+        business_nature: Government agency
+        company_website: https://www.gov.uk/
+    BeneficiaryRequirements:
+      type: object
+      description: Beneficiary requirements.
+      properties:
+        payment_type:
+          description: The type of payment - 'priority' (Swift) or 'regular' (local).
+          type: string
+          enum:
+          - priority
+          - regular
+        acct_number:
+          type: string
+          description: An account number is required.
+        bic_swift:
+          type: string
+          description: BIC / Swift code is required.
+        beneficiary_address:
+          type: string
+          description: Beneficiary's address
+        beneficiary_city:
+          type: string
+          description: Beneficiary's city
+        beneficiary_country:
+          type: string
+          description: Beneficiary's country
+        beneficiary_postcode:
+          type: string
+          description: Beneficiary's postcode
+        beneficiary_state_or_province:
+          type: string
+          description: Beneficiary's state or province
+        beneficiary_first_name:
+          type: string
+          description: Beneficiary's first name
+        beneficiary_last_name:
+          type: string
+          description: Beneficiary's last name
+        beneficiary_entity_type:
+          type: string
+          description: Type of entity
+          enum:
+          - company
+          - individual
+        sort_code:
+          type: string
+          description: A sort code is required.
+        aba:
+          type: string
+          description: An ABA (American Bankers Association) routing number is required.
+        bsb_code:
+          type: string
+          description: A BSB (Bank State Branch) number is required.
+        institution_no:
+          type: string
+          description: An institution number is required.
+        bank_code:
+          type: string
+          description: A bank code is required.
+        branch_code:
+          type: string
+          description: A branch code is required.
+        clabe:
+          type: string
+          description: A CLABE (Clave Bancaria Estandarizada) code is required.
+        cnaps:
+          type: string
+          description: A CNAPS (China National Advanced Payment System) code is required.
+      example:
+        payment_type: regular
+        acct_number: ^\\d{1,17}$
+        aba: ^[0-9A-Z]{9}$
+        beneficiary_address: ^.{1,255}
+        beneficiary_city: ^.{1,255}
+        beneficiary_country: ^[A-z]{2}$
+        beneficiary_postcode: ^.{1,255}
+        beneficiary_state_or_province: ^.{1,255}
+        beneficiary_first_name: ^.{1,255}
+        beneficiary_last_name: ^.{1,255}
+        beneficiary_entity_type: individual
+    BeneficiaryAccountVerificationResult:
+      type: object
+      description: Beneficiary account verification result.
+      properties:
+        answer:
+          description: The account verification result - 'full_match', 'close_match' or 'no_match'.
+          type: string
+          enum:
+          - close_match
+          - full_match
+          - no_match
+        actual_name:
+          type: string
+          description: The actual name of the account holder.
+        reason_code:
+          type: string
+          description: Encoded reason.
+        reason:
+          type: string
+          description: Description of the reason.
+        reason_type:
+          type: string
+          description: Category of reason - 'okay', 'warning' or 'rejected'.
+      example:
+        answer: full_match
+        actual_name: Joe Bloggs
+        reason_code: AV100
+        reason: Full match
+        reason_type: okay
+    CancelTransferError:
+      type: object
+      description: 'Client error information for the Cancel Transfer endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    Contact:
+      type: object
+      description: Contact.
+      properties:
+        login_id:
+          type: string
+          description: The contact's Currencycloud login ID.
+        id:
+          type: string
+          description: The contact's ID.
+        your_reference:
+          type: string
+          description: The user-generated reference code given to the contact.
+        first_name:
+          type: string
+          description: The contact's first name.
+        last_name:
+          type: string
+          description: The contact's last name.
+        account_id:
+          type: string
+          description: The contact's account ID.
+        account_name:
+          type: string
+          description: The account name.
+        status:
+          type: string
+          description: Contact status - "enabled" allows the contact to conduct activity on the sub-account, "not_enabled"
+            disables the contact.
+        phone_number:
+          type: string
+          description: The contact's phone number.
+        mobile_phone_number:
+          type: string
+          description: The contact's mobile phone number.
+        locale:
+          type: string
+          description: The contact's locale.
+        timezone:
+          type: string
+          description: The contact's timezone.
+        email_address:
+          type: string
+          description: The contact's email address.
+        date_of_birth:
+          type: string
+          description: The contact's date of birth.
+        created_at:
+          type: string
+          description: The date the contact record was created.
+        updated_at:
+          type: string
+          description: The date the contact record was last updated.
+      example:
+        login_id: john.smith
+        id: 543477161-91de-012f-e284-1e0030c7f352
+        your_reference: ACME12345
+        first_name: John
+        last_name: Smith
+        account_id: 87077161-91de-012f-e284-1e0030c7f352
+        account_name: Company PLC
+        status: enabled
+        phone_number: 06554 87845
+        mobile_phone_number: 07564 534 54
+        locale: en-US
+        timezone: Europe/London
+        email_address: john.smith@company.com
+        date_of_birth: '1980-01-22T00:00:00.000Z'
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+    Conversion:
+      type: object
+      description: Conversion.
+      properties:
+        id:
+          type: string
+          description: Conversion UUID
+        account_id:
+          type: string
+          description: UUID of the Account that the Conversion belongs to.
+        creator_contact_id:
+          type: string
+          description: UUID of the Contact that requested the conversion.
+        short_reference:
+          type: string
+          description: A human readable unique trade indentifier, in the format YYYYMMDD-XXXXXX.
+        settlement_date:
+          type: string
+          description: The date and time by which funds need to be available to settle the trade.
+        conversion_date:
+          type: string
+          description: The date the conversion will be made.
+        status:
+          type: string
+          description: Current conversion status.
+          enum:
+          - awaiting_authorisation
+          - awaiting_funds
+          - closed
+          - funds_arrived
+          - funds_being_processed
+          - funds_sent
+          - trade_settled
+          - trade_settling
+        currency_pair:
+          description: Concatenated string of the two currencies traded, eg. "USDEUR".
+          type: string
+        buy_currency:
+          type: string
+          description: Three character ISO code for the currency being bought.
+        sell_currency:
+          type: string
+          description: Three character ISO code for the currency being sold.
+        fixed_side:
+          type: string
+          description: Which currency side is fixed -  the buy or sell one.
+          enum:
+          - buy
+          - sell
+        partner_buy_amount:
+          type: string
+          description: The amount of buy currency for a partner.
+        partner_sell_amount:
+          type: string
+          description: The amount of sell currency for a partner.
+        client_buy_amount:
+          type: string
+          description: The amount of buy currency for a client.
+        client_sell_amount:
+          type: string
+          description: The amount of sell currency for a client.
+        mid_market_rate:
+          type: string
+          description: The midpoint between the buy and sell rates.
+        core_rate:
+          type: string
+          description: The market rate.
+        partner_rate:
+          type: string
+          description: The market rate + Currencycloud commission (if applicable).
+        client_rate:
+          type: string
+          description: The rate that will be returned to your customer after all spread has been applied.
+        deposit_required:
+          type: boolean
+          description: Is a deposit required for the conversion?
+          enum:
+          - true
+          - false
+        deposit_amount:
+          type: string
+          description: The amount of a deposit required.
+        deposit_currency:
+          type: string
+          description: Three-letter ISO currency code for the currency the deposit is shown in.
+        deposit_status:
+          type: string
+          description: Deposit status
+          enum:
+          - awaiting_deposit
+          - deposit_received
+          - not_required
+        deposit_required_at:
+          type: string
+          description: Date by which deposit is required, format YYYY-MM-DDThh:mm:ss.SSSZ.
+        unallocated_funds:
+          type: string
+          description: The buy amount from the trade, that has not been allocated towards funding a payment.
+        payment_ids:
+          type: array
+          description: The id of payments linked with this conversion - these payments won’t be processed until the conversion
+            settles.
+          items:
+            type: string
+        unique_request_id:
+          description: User-generated idempotency key. Beneficial for request tracking / management.
+          type: string
+        created_at:
+          type: string
+          description: Date the conversion was created.
+        updated_at:
+          type: string
+          description: Date the conversion was last updated.
+      example:
+        id: c9b6b851-10f9-4bbf-881e-1d8a49adf7d8
+        account_id: 0386e472-8d2b-45a8-9c14-a393dce5bf3a
+        creator_contact_id: ac743762-5860-4b78-9c6a-82c5bca68867
+        short_reference: 20140507-VRTNFC
+        settlement_date: '2023-12-31T23:59:59.000Z'
+        conversion_date: '2023-12-31T23:59:59.000Z'
+        status: awaiting_funds
+        currency_pair: GBPUSD
+        buy_currency: GBP
+        sell_currency: USD
+        fixed_side: buy
+        partner_buy_amount: '1000.00'
+        partner_sell_amount: '1587.80'
+        client_buy_amount: '1000.00'
+        client_sell_amount: '1594.90'
+        mid_market_rate: '1.5868'
+        core_rate: '1.5871'
+        partner_rate: '1.5878'
+        client_rate: '1.5949'
+        deposit_required: true
+        deposit_amount: '47.85'
+        deposit_currency: GBP
+        deposit_status: awaiting_deposit
+        deposit_required_at: '2023-12-31T23:59:59.000Z'
+        unallocated_funds: '1000.00'
+        payment_ids:
+        - b934794f-d810-4b4a-b360-5a0f47b7126e
+        unique_request_id: 1234567890abc
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+    ConversionCancellationQuote:
+      type: object
+      description: Projected cost to cancel a conversion.
+      properties:
+        amount:
+          type: string
+          description: The cost to cancel the conversion.
+        currency:
+          type: string
+          description: The currency of the cost to cancel the conversio - a three-letter ISO currency code.
+        event_date_time:
+          type: string
+          format: date-time
+          description: The date and time of the conversion cancellation quote.
+      example:
+        amount: 100
+        currency: GBP
+        event_date_time: '2023-07-14T17:03:11.000Z'
+    ConversionProfitAndLoss:
+      type: object
+      description: Recognised profit / loss on a conversion.
+      properties:
+        conversion_profit_and_losses:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConversionCancellation'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      example:
+        conversion_profit_and_losses:
+        - account_id: 2090939e-b2f7-3f2b-1363-4d235b3f58af
+          contact_id: 8a98ebac-6f88-e205-a685-4d235b1b088b
+          event_account_id: 2090939e-b2f7-3f2b-1363-4d235b3f58af
+          event_contact_id: 8a98ebac-6f88-e205-a685-4d235b1b088b
+          conversion_id: 648945d7-1cff-4dae-a432-7d5501c77a8a
+          amount: '-0.28'
+          currency: GBP
+          notes: Cancel the conversion due to personal issues
+          event_type: self_service_cancellation
+          event_date_time: '2023-11-10T12:18:56.000Z'
+        - account_id: 67e1b252-40a7-454d-a097-8f77d385889d
+          contact_id: 04d0c252-7b78-4d72-b408-df78841e3ddc
+          event_account_id: 67e1b252-40a7-454d-a097-8f77d385889d
+          event_contact_id: 04d0c252-7b78-4d72-b408-df78841e3ddc
+          conversion_id: 540c2ea3-9916-4efb-9cd9-0f8ce63a5c04
+          amount: '-0.83'
+          currency: USD
+          notes: Cancel due to very important reason
+          event_type: self_service_cancellation
+          event_date_time: '2023-11-10T12:18:56.000Z'
+        pagination:
+          total_entries: 2
+          total_pages: 1
+          current_page: 1
+          per_page: 25
+          previous_page: -1
+          next_page: 2
+          order: created_at
+          order_asc_desc: asc
+    ConversionCancellation:
+      type: object
+      description: Cancelled Conversion
+      properties:
+        account_id:
+          type: string
+          description: UUID of the Account that the Conversion belongs to.
+        contact_id:
+          type: string
+          description: UUID of the Contact that performed the action that generated profit or loss.
+        event_account_id:
+          type: string
+          description: The account_id of the trade's account.
+        event_contact_id:
+          type: string
+          description: The contact_id of the trade's contact.
+        conversion_id:
+          type: string
+          description: UUID of the Conversion.
+        amount:
+          type: string
+          description: The amount of the profit or loss.
+        currency:
+          type: string
+          description: Three-letter ISO currency code for the currency the amount is shown in.
+        notes:
+          type: string
+          description: Additional information regarding the event.
+        event_type:
+          type: string
+          description: The type of event (e.g. cancellation).
+        event_date_time:
+          type: string
+          format: date-time
+          description: The date and time of the quote.
+      example:
+        account_id: 2090939e-b2f7-3f2b-1363-4d235b3f58af
+        contact_id: 8a98ebac-6f88-e205-a685-4d235b1b088b
+        event_account_id: 2090939e-b2f7-3f2b-1363-4d235b3f58af
+        event_contact_id: 8a98ebac-6f88-e205-a685-4d235b1b088b
+        conversion_id: 648945d7-1cff-4dae-a432-7d5501c77a8a
+        amount: '-0.28'
+        currency: GBP
+        notes: Cancel the conversion due to personal issues
+        event_type: self_service_cancellation
+        event_date_time: '2023-11-10T12:18:56.000Z'
+    ConversionDateChange:
+      type: object
+      description: Conversion Date change record
+      properties:
+        conversion_id:
+          type: string
+          description: UUID of the Conversion.
+        amount:
+          type: string
+          description: The cost of changing the date of the conversion.
+        currency:
+          type: string
+          description: The currency of the cost to change the conversion date. A three-letter ISO currency code.
+        new_conversion_date:
+          type: string
+          description: The new date the conversion will be made.
+        new_settlement_date:
+          type: string
+          description: The new date and time by which funds need to be available to settle the trade.
+        old_conversion_date:
+          type: string
+          description: The previous date the conversion was to be made.
+        old_settlement_date:
+          type: string
+          description: The previous date and time by which funds needed to be available to settle the trade.
+        event_date_time:
+          type: string
+          description: The date and time of the date change or date change quote.
+    ConversionDates:
+      type: object
+      description: Conversion dates.
+      properties:
+        first_conversion_cutoff_datetime:
+          type: string
+          format: date-time
+          description: The first conversion date and cutoff time by when conversions can be created.
+        first_conversion_date:
+          type: string
+          format: date
+          description: The first available date that a trade can be made on, in the format YYYY-MM-DD.
+        next_day_conversion_date:
+          type: string
+          format: date
+          description: The next available date that a trade can be made on, in the format YYYY-MM-DD.
+        default_conversion_date:
+          type: string
+          format: date
+          description: The default available date that a trade can be made on, in the format YYYY-MM-DD.
+        optimize_liquidity_conversion_date:
+          type: string
+          format: date
+          description: Optimal conversion date for maximizing chances of getting a successful rate.
+        invalid_conversion_dates:
+          type: object
+          additionalProperties:
+            type: string
+            description: Maps dates (eg. "2020-12-27") to string values that explain why trading is not available on the date
+              (eg. "No trading on Sunday").
+        offline_conversion_dates:
+          type: array
+          items:
+            type: string
+            description: The list of available offline conversion dates.
+      example:
+        first_conversion_cutoff_datetime: '2020-11-18T15:50:00+00:00'
+        first_conversion_date: '2020-11-18'
+        next_day_conversion_date: '2020-11-19'
+        default_conversion_date: '2020-11-20'
+        optimize_liquidity_conversion_date: '2020-11-23'
+        invalid_conversion_dates:
+          '2020-11-21': No trading on Saturday
+          '2020-11-22': No trading on Sunday
+          '2020-11-28': No trading on Saturday
+          '2020-11-29': No trading on Sunday
+          '2020-12-05': No trading on Saturday
+          '2020-12-06': No trading on Sunday
+          '2020-12-12': No trading on Saturday
+          '2020-12-13': No trading on Sunday
+          '2020-12-19': No trading on Saturday
+          '2020-12-20': No trading on Sunday
+          '2020-12-25': Christmas Day
+          '2020-12-26': No trading on Saturday
+          '2020-12-27': No trading on Sunday
+          '2020-12-28': Boxing Day OBS
+          '2021-01-01': New Year's Day
+          '2021-01-02': No trading on Saturday
+          '2021-01-03': No trading on Sunday
+        offline_conversion_dates:
+        - '2020-11-23'
+    ConversionSplitDetails:
+      properties:
+        id:
+          type: string
+          description: Conversion ID
+        short_reference:
+          type: string
+          description: A human readable unique trade indentifier, in the format YYYYMMDD-XXXXXX.
+        sell_currency:
+          type: string
+          description: Three character ISO code for currency sold.
+        buy_currency:
+          type: string
+          description: Three character ISO code for currency bought.
+        buy_amount:
+          type: string
+          description: The amount of the buy_currency being bought.
+        sell_amount:
+          type: string
+          description: The amount of the sell_currency being sold.
+        settlement_date:
+          type: string
+          format: date-time
+          description: The date and time by which funds need to be available to settle the trade.
+        conversion_date:
+          type: string
+          format: date-time
+          description: The date the conversion will be made.
+        status:
+          type: string
+          description: Status of the related trade.
+          enum:
+          - awaiting_authorisation
+          - awaiting_funds
+          - closed
+          - funds_arrived
+          - funds_being_processed
+          - funds_sent
+          - trade_settled
+          - trade_settling
+    ConversionSplit:
+      type: object
+      properties:
+        parent_conversion:
+          description: The parent conversion.
+          allOf:
+          - $ref: '#/components/schemas/ConversionSplitDetails'
+        child_conversion:
+          description: The child conversion.
+          allOf:
+          - $ref: '#/components/schemas/ConversionSplitDetails'
+    ConversionSplitHistory:
+      type: object
+      properties:
+        origin_conversion:
+          description: The original conversion (before split).
+          allOf:
+          - $ref: '#/components/schemas/ConversionSplitDetails'
+        parent_conversion:
+          description: The parent conversion (after split).
+          allOf:
+          - $ref: '#/components/schemas/ConversionSplitDetails'
+        child_conversions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ConversionSplitDetails'
+          description: The child conversion (after split).
+    ReportRequest:
+      type: object
+      description: Report record
+      properties:
+        id:
+          type: string
+          description: Unique ID for the report.
+        short_reference:
+          type: string
+          description: Human readable unique ID.
+        description:
+          type: string
+          description: Description provided when the report was created.
+        search_params:
+          type: object
+          default: {}
+          description: Parameters to select specific range of items that we want to see in the report.
+        report_type:
+          type: string
+          description: The type of report - conversion or payment.
+          enum:
+          - conversion
+          - payment
+        status:
+          type: string
+          description: The status of the report
+          enum:
+          - completed
+          - expired
+          - failed
+          - processing
+        expiration_date:
+          type: string
+          format: date
+          description: ISO 8601 Date of report expiration.
+        report_url:
+          type: string
+          description: URL to use to download the CSV report.
+        account_id:
+          type: string
+          description: ID of the account.
+        contact_id:
+          type: string
+          description: ID of the contact.
+        created_at:
+          type: string
+          format: date
+          description: ISO 8601 date when the report was created.
+        updated_at:
+          type: string
+          format: date
+          description: ISO 8601 date when the report was last updated.
+      example:
+        id: 950dac23-c4af-4a6a-ba19-344560abe2a9
+        short_reference: RP-30250607-VDTMFA
+        description: Description, which was provided during the report creation process
+        search_params:
+          short_reference: RP-30250607-VDTMFA
+          description: Description, which was provided during the report creation process
+          account_id: 9a7ba866-56d1-39c6-8ca2-12cb4141213a
+          contact_id: 543a7716c-816e-01af-3214-2e0030f6f25a
+          created_at_from: '2014-01-12'
+          created_at_to: '2014-01-17'
+          expiration_date_from: '2014-01-12'
+          expiration_date_to: '2014-01-17'
+          status: completed
+          report_type: Payment
+        report_type: payment
+        status: completed
+        expiration_date: '2023-03-23T00:00:00.000Z'
+        report_url: https://tcc.s3.amazonaws.com/reports/transaction_reports/000/000/011/transaction_report_23_03_2020.csv?1471682433
+        account_id: B7DE235A-FF5D-4252-83C2-06A605267FEA
+        contact_id: 543477161-91de-012f-e284-1e0030c7f352
+        created_at: '2023-03-16T23:59:59.000Z'
+        updated_at: '2023-03-16T23:59:59.000Z'
+    FundingTransaction:
+      description: The transaction information.
+      properties:
+        id:
+          description: The Related Entity UUID (related_entity_id) for the transaction.
+          type: string
+        amount:
+          description: The transaction amount.
+          type: string
+        currency:
+          description: The three-letter currency code.
+          type: string
+        rail:
+          description: The transaction rail.
+          type: string
+        additional_information:
+          description: Any additional information.
+          type: string
+        receiving_account_routing_code:
+          description: The routing code.
+          type: string
+        value_date:
+          description: The value date in ISO-8601 format.
+          format: date-time
+          type: string
+        receiving_account_number:
+          description: The transaction receiving account number.
+          type: string
+        receiving_account_iban:
+          description: The transaction receiving account IBAN.
+          type: string
+        created_at:
+          description: The created at date in ISO-8601 format.
+          format: date-time
+          type: string
+        updated_at:
+          description: The last time the transaction was updated in ISO-8601 format.
+          format: date-time
+          type: string
+        completed_at:
+          description: The completed date in ISO-8601 format.
+          format: date-time
+          type: string
+        sender:
+          $ref: '#/components/schemas/SenderInformation'
+      example:
+        additional_information: ABCD20231016143117
+        amount: 1.11
+        completed_at: 2022-12-03 10:15:30+00:00
+        created_at: 2022-12-03 10:15:30+00:00
+        currency: USD
+        id: 4924919a-6c28-11ee-a3e3-63774946bad2
+        rail: SEPA
+        receiving_account_iban: null
+        receiving_account_number: 32847346
+        receiving_account_routing_code: 123456789
+        updated_at: 2022-12-03 10:15:30+00:00
+        value_date: 2022-12-03 10:00:00+00:00
+        sender:
+          sender_account_number: 8119645406
+          sender_address: Some street
+          sender_bic: null
+          sender_country: GB
+          sender_iban: null
+          sender_id: 5c675fa4-fdf0-4ee6-b5bb-156b36765433
+          sender_name: Test sender
+          sender_routing_code: null
+      type: object
+    CreateAccountError:
+      type: object
+      description: 'Client error information for the Create Account endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    CreateBeneficiaryError:
+      type: object
+      description: 'Client error information for the Create Beneficiary endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    CreateContactError:
+      type: object
+      description: 'Client error information for the Create Contact endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    CreateConversionError:
+      type: object
+      description: 'Client error information for the Create Conversion endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    CreatePaymentAuthorisationError:
+      type: object
+      description: 'Client error information for the Create Payment Authorise endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    CreatePaymentError:
+      type: object
+      description: 'Client error information for the Create Payment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    CreateTransferError:
+      type: object
+      description: Client error information for the Create Transfer endpoint.
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    DeleteBeneficiaryError:
+      type: object
+      description: 'Client error information for the Delete Beneficiary endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    DeletePaymentError:
+      type: object
+      description: 'Client error information for the Delete Payment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindAccountsError:
+      type: object
+      description: 'Client error information for the Find Accounts endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindBalancesError:
+      type: object
+      description: 'Client error information for the Find Balances endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindBeneficiariesError:
+      type: object
+      description: 'Client error information for the Find Beneficiaries endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindContactsError:
+      type: object
+      description: 'Client error information for the Find Contacts endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindConversionsError:
+      type: object
+      description: 'Client error information for the Find Conversions endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindFundingAccountsError:
+      type: object
+      description: 'Client error information for the Find Funding Accounts endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindPaymentsError:
+      type: object
+      description: 'Client error information for the Get Payments endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindTransactionsError:
+      type: object
+      description: 'Client error information for the Find Transactions endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FindTransfersError:
+      type: object
+      description: 'Client error information for the Find Transfers endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetFundingTransactionError:
+      description: 'Client error information for the Get Funding Transaction endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    FundingAccount:
+      type: object
+      description: FundingAccount.
+      required:
+      - id
+      - account_id
+      - account_number
+      - account_number_type
+      - account_holder_name
+      - bank_name
+      - bank_address
+      - bank_country
+      - currency
+      - payment_type
+      - routing_code
+      - routing_code_type
+      - created_at
+      - updated_at
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: The SSI's unique UUID.
+        account_id:
+          type: string
+          description: The account ID the SSI is attached to. If money is paid to the account details, this account will be
+            credited.
+        account_number:
+          type: string
+          description: The account number to use when adding funds to the account.
+        account_number_type:
+          type: string
+          description: The type of account number provided (e.g. account number of IBAN).
+          enum:
+          - account_number
+          - iban
+        account_holder_name:
+          type: string
+          description: The name of the account used to make a payment.
+        bank_name:
+          type: string
+          description: The name of the bank the account is held with.
+        bank_address:
+          type: string
+          description: The address of the bank the account is held with.
+        bank_country:
+          type: string
+          description: The 2 digit ISO country code where the bank is based.
+        currency:
+          type: string
+          description: The currency that should be sent to these account details.
+        payment_type:
+          type: string
+          description: The type of payment that can be made into the account details provided. Regular - a local scheme such
+            as Faster Payments in the UK. Priority - a priority payment e.g. FEDwire or Swift.
+          enum:
+          - any
+          - priority
+          - regular
+        routing_code:
+          type: string
+          description: The particular routing code for this account number.
+        routing_code_type:
+          type: string
+          description: The type of routing number.
+          enum:
+          - routing_code
+          - giro_routing_code
+          - ach_routing_number
+          - fast_routing_code
+          - sort_code
+          - wire_routing_number
+          - bic_swift
+          - meps_routing_code
+        created_at:
+          type: string
+          description: The date-time the SSI was added to the account.
+          format: date-time
+        updated_at:
+          type: string
+          description: The date-time the SSI was last updated on the account.
+          format: date-time
+      example:
+        id: b7981972-8e29-485b-8a4a-9643fc9ae4ea
+        account_id: 8d98bdc8-e8e3-47dc-bd08-3dd0f4f7ea7b
+        account_number: GB61TCCL00997950423807
+        account_number_type: IBAN
+        account_holder_name: Jon Doe
+        bank_name: The Currency Cloud
+        bank_address: 12 Steward Street, The Steward Building, London, E1 6FQ, GB
+        bank_country: UK
+        currency: EUR
+        payment_type: regular
+        routing_code: TCCLGB31
+        routing_code_type: bic_swift
+        created_at: '2018-05-14T14:18:30+00:00'
+        updated_at: '2018-05-14T14:18:30+00:00'
+    GenerateHMACKeyError:
+      type: object
+      description: 'Client error information for the Contacts Generate HMAC Key endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GenerateReportError:
+      type: object
+      description: 'Client error information for the Generate Report endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetAccountError:
+      type: object
+      description: 'Client error information for the Get Account endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetAccountComplianceSettingsError:
+      type: object
+      description: 'Client error information for the Get Compliance Settings endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    UpdateAccountComplianceSettingsError:
+      type: object
+      description: 'Client error information for the Get Compliance Settings endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetAccountPaymentChargesSettingsError:
+      type: object
+      description: 'Client error information for the Get Account Payment Charges Settings endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    ManageAccountPaymentChargesSettingsError:
+      type: object
+      description: 'Client error information for the Manage Account Payment Charges Settings endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetAvailableCurrenciesError:
+      type: object
+      description: 'Client error information for the Get Available Currencies endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetBalanceError:
+      type: object
+      description: 'Client error information for the Get Balance endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetBankDetailsError:
+      type: object
+      description: 'Client error information for the Get Bank Details endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetBasicRatesError:
+      type: object
+      description: 'Client error information for the Get Basic Rates endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetBeneficiaryError:
+      type: object
+      description: 'Client error information for the Get Beneficiary endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetBeneficiaryRequirementsError:
+      type: object
+      description: 'Client error information for the Get Beneficiary Requirements endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetContactError:
+      type: object
+      description: 'Client error information for the Get Contact endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetConversionDatesError:
+      type: object
+      description: 'Client error information for the Get Conversion Dates endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetConversionError:
+      type: object
+      description: 'Client error information for the Get Conversion endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetDetailedRatesError:
+      type: object
+      description: 'Client error information for the Get Detailed Rates endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPayerError:
+      type: object
+      description: 'Client error information for the Get Payer endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPayerRequirementsError:
+      type: object
+      description: 'Client error information for the Get Payer Requirements endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentDatesError:
+      type: object
+      description: 'Client error information for the Get Payment Dates endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentPurposeCodesError:
+      type: object
+      description: 'Client error information for the Get Payment Purpose Codes endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentError:
+      type: object
+      description: 'Client error information for the Get Payment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentDeliveryDateError:
+      type: object
+      description: 'Client error information for the Get Payment Delivery Date endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentFeeRulesError:
+      type: object
+      description: 'Client error information for the Get Payment Fee Rules endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentSubmissionError:
+      type: object
+      description: 'Client error information for the Get Payment Submission endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetPaymentTrackingInfoError:
+      type: object
+      description: 'Client error information for the Get Payment Tracking Info endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetQuotePaymentFeeError:
+      type: object
+      description: 'Client error information for the Get Quote Payment Fee endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetReportRequestError:
+      type: object
+      description: 'Client error information for the Get Report Request endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetSenderError:
+      type: object
+      description: 'Client error information for the Get Sender endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetSettlementAccountsError:
+      type: object
+      description: 'Client error information for the Get Settlement Accounts endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetTransactionError:
+      type: object
+      description: 'Client error information for the Get Transaction endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetTransferError:
+      type: object
+      description: 'Client error information for the Get Transfer endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    GetWithdrawalAccountError:
+      type: object
+      description: 'Client error information for the Get WithdrawalAccount endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    HMACKey:
+      type: object
+      description: HMAC Key.
+      required:
+      - hmac_key
+      additionalProperties: false
+      properties:
+        hmac_key:
+          type: string
+          description: The generated HMAC Key.
+      example:
+        hmac_key: 9562c7c1094dfe8f46125aa3f3c0d141471fadd443828bb0
+    LoginError:
+      type: object
+      description: 'Login error.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+      example:
+        error_code: auth_invalid_user_login_details
+        error_messages:
+          api_key:
+          - code: api_key_length_is_invalid
+            message: api_key should be 64 character(s) long
+            params:
+              length: 64
+    NotFoundError:
+      type: object
+      description: Resource not found.
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    Pagination:
+      type: object
+      description: Pagination.
+      properties:
+        total_entries:
+          type: integer
+        total_pages:
+          type: integer
+        current_page:
+          type: integer
+        per_page:
+          type: integer
+          description: Number of results per page.
+        previous_page:
+          type: integer
+        next_page:
+          type: integer
+        order:
+          type: string
+          description: The field name by which the results are sorted.
+        order_asc_desc:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: asc
+          description: Whether results are sorted in ascending or descending order.
+      example:
+        total_entries: 1
+        total_pages: 1
+        current_page: 1
+        per_page: 25
+        previous_page: -1
+        next_page: 2
+        order: created_at
+        order_asc_desc: asc
+    Payer:
+      type: object
+      description: Payer
+      properties:
+        id:
+          type: string
+          description: Unique UUID for the payer.
+        legal_entity_type:
+          type: string
+          description: Payer's entity type - company or individual.
+          enum:
+          - company
+          - individual
+        company_name:
+          type: string
+          description: The name of the company (if the payer is a company).
+        first_name:
+          type: string
+          description: Payer's first name.
+        last_name:
+          type: string
+          description: Payer's last name.
+        address:
+          type: array
+          items:
+            type: string
+            description: Line of address.
+        city:
+          type: string
+        state_or_province:
+          type: string
+        country:
+          type: string
+          description: Two-letter ISO country code.
+        identification_type:
+          type: string
+          description: The legal document used to verify the identity of the payer (e.g. passport).
+        identification_value:
+          type: string
+          description: A unique reference code for the identification document, such as a passport number.
+        postcode:
+          type: string
+        date_of_birth:
+          type: string
+        created_at:
+          type: string
+        updated_at:
+          type: string
+      example:
+        id: 543477161-91de-012f-e284-1e0030c7f3123
+        legal_entity_type: company
+        company_name: Acme Corporation
+        first_name: ''
+        last_name: ''
+        address:
+        - 164 Bishopsgate
+        - London
+        city: London
+        state_or_province: ''
+        country: GB
+        identification_type: incorporation_number
+        identification_value: 123123
+        postcode: EC2M 4LX
+        date_of_birth: '2023-12-31T23:59:59.000Z'
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+    PayerRequirements:
+      type: object
+      description: Payer requirements.
+      properties:
+        payer_entity_type:
+          description: Legal entity type - company or individual.
+          enum:
+          - company
+          - individual
+          type: string
+        payment_type:
+          description: Type of payment - regular (local) or priority (Swift).
+          enum:
+          - priority
+          - regular
+          type: string
+        required_fields:
+          description: The required payer fields for the payment.
+          type: array
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+              validation_rule:
+                type: string
+      example:
+        payer_entity_type: company
+        payment_type: priority
+        required_fields:
+        - name: payer_country
+          validation_rule: ^[A-z]{2}$
+        - name: payer_city
+          validation_rule: ^.{1,255}
+        - name: payer_address
+          validation_rule: ^.{1,255}
+        - name: payer_postcode
+          validation_rule: ^.{1,255}
+        - name: payer_company_name
+          validation_rule: ^.{1,255}
+    Payment:
+      type: object
+      description: Payment
+      properties:
+        id:
+          type: string
+          description: Payment UUID
+        amount:
+          type: string
+          description: Payment amount
+        beneficiary_id:
+          type: string
+          description: Beneficiary UUID
+        currency:
+          type: string
+          description: Payment currency
+        reference:
+          type: string
+          description: Payment reference
+        reason:
+          type: string
+          description: Reason for payment.
+        status:
+          type: string
+          description: Payment status
+        creator_contact_id:
+          type: string
+          description: Contact UUID of payment creator.
+        payment_type:
+          type: string
+          description: Type of payment - priority(Swift) or regular(local).
+        transferred_at:
+          type: string
+          description: Date of payment processing.
+        authorisation_steps_required:
+          type: string
+          description: Number of approvals required for the payment.
+        estimated_arrival:
+          type: string
+          description: Estimated date of payment.
+        payment_date:
+          type: string
+          description: Payment date.
+        last_updater_contact_id:
+          type: string
+          description: Contact UUID of user who last updated the record.
+        short_reference:
+          type: string
+          description: Short reference code.
+        conversion_id:
+          type: string
+          description: Conversion UUID
+        failure_reason:
+          type: string
+          description: A reason for why the payment failed.
+        payer_id:
+          type: string
+          description: Payer UUID
+        payer_details_source:
+          type: string
+          description: If the payment is a 3rd party one, the value will be "account". If  it is a 4th party payment, the
+            value will be "payer".
+        created_at:
+          type: string
+          description: Date and time of when the payment was created.
+        updated_at:
+          type: string
+          description: Date and time of when the payment was last updated.
+        payment_group_id:
+          type: string
+          description: Payment group ID.
+        unique_request_id:
+          type: string
+          description: The user-generated idempotency key provided for the payment.
+        failure_returned_amount:
+          type: string
+          description: The amount returned on failure.
+        ultimate_beneficiary_name:
+          type: string
+          description: The name of the ultimate beneficiary.
+        purpose_code:
+          type: string
+          description: Payment purpose code.
+        fee_amount:
+          type: string
+          description: Fee amount
+        fee_currency:
+          type: string
+          description: Currency code for fee.
+        review_status:
+          type: string
+          description: Compliance review status - 'passed', 'in_review' or 'rejected'.
+          enum:
+          - in_review
+          - passed
+          - rejected
+        invoice_number:
+          type: string
+          description: The invoice number related to the payment. Can be up to 30 characters.
+        invoice_date:
+          type: string
+          description: The date of the invoice related to the payment. ISO 8601 format YYYY-MM-DD.
+      example:
+        id: 543477161-91de-012f-e284-1e0030c7f3123
+        short_reference: 140416-GGJBNQ001
+        beneficiary_id: 543477161-91de-012f-e284-1e0030c7f352
+        conversion_id: 049bab6d-fe2a-42e1-be0f-531c59f838ea
+        amount: '1250000.00'
+        currency: GBP
+        status: ready_to_send
+        payment_type: regular
+        reference: INVOICE 9876
+        reason: Salary for March
+        estimated_arrival: '2023-12-31T00:00:00.000Z'
+        payment_date: '2023-12-31T23:59:59.000Z'
+        transferred_at: '2023-12-31T23:59:59.000Z'
+        authorisation_steps_required: '0'
+        creator_contact_id: ab3477161-91de-012f-e284-1e0030c7f35c
+        last_updater_contact_id: ab3477161-91de-012f-e284-1e0030c7f35c
+        failure_reason: ''
+        payer_id: ''
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+        payment_group_id: 20140428-CJRRJM
+        unique_request_id: 1234567890abc
+        failure_returned_amount: ''
+        ultimate_beneficiary_name: Some beneficiary name
+        purpose_code: ''
+        fee_amount: '10.00'
+        fee_currency: EUR
+        review_status: in_review
+        invoice_number: INV01
+        invoice_date: '2023-07-03'
+    PaymentAuthorisations:
+      type: object
+      description: Payment Authorisations.
+      properties:
+        authorisations:
+          type: array
+          items:
+            $ref: '#/components/schemas/PaymentAuthorisation'
+    PaymentAuthorisation:
+      type: object
+      description: Payment Authorisation.
+      properties:
+        payment_id:
+          type: string
+        payment_status:
+          type: string
+        updated:
+          type: string
+        error:
+          type: string
+        auth_steps_taken:
+          type: string
+        auth_steps_required:
+          type: string
+        short_reference:
+          type: string
+      example:
+        payment_id: 27966e22-5bdc-4675-923d-041c6be5b239
+        payment_status: ready_to_send
+        updated: true
+        error: null
+        auth_steps_taken: 3
+        auth_steps_required: 0
+        short_reference: 180628-FGVXPX001
+    PaymentDates:
+      type: object
+      description: Payment dates.
+      properties:
+        invalid_payment_dates:
+          type: object
+          description: Invalid payment dates with reason.
+          additionalProperties:
+            type: string
+            description: Maps dates (eg. "2023-12-31") to string values that explains why payments cannot be made on this
+              date (eg. "No trading on Sunday").
+        first_payment_date:
+          description: Frist possible payment date.
+          type: string
+      example:
+        invalid_payment_dates:
+          '2013-04-18': Good Friday
+          '2013-04-19': No trading on Saturday
+          '2013-04-20': No trading on Sunday
+          '2013-04-21': Easter Monday
+          '2013-04-26': No trading on Saturday
+          '2013-04-27': No trading on Sunday
+          '2013-05-03': No trading on Saturday
+          '2013-05-04': No trading on Sunday
+          '2013-05-05': Early May Bank Holiday
+          '2013-05-10': No trading on Saturday
+          '2013-05-11': No trading on Sunday
+          '2013-05-17': No trading on Saturday
+          '2013-05-18': No trading on Sunday
+          '2013-05-24': No trading on Saturday
+          '2013-05-25': No trading on Sunday
+          '2013-05-26': Spring Bank Holiday
+          '2013-05-31': No trading on Saturday
+          '2013-06-01': No trading on Sunday
+          '2013-06-07': No trading on Saturday
+          '2013-06-08': No trading on Sunday
+          '2013-06-14': No trading on Saturday
+        first_payment_date: '2013-04-15T00:00:00.000Z'
+    PaymentDeliveryDate:
+      type: object
+      description: Payment Delivery Date
+      required:
+      - payment_date
+      - payment_delivery_date
+      - payment_cutoff_time
+      - payment_type
+      - currency
+      - bank_country
+      additionalProperties: false
+      properties:
+        payment_date:
+          type: string
+          description: The date when the payment will be released.
+        payment_delivery_date:
+          type: string
+          description: Date that we expect the payment to be delivered and available in the beneficiary bank account.
+        payment_cutoff_time:
+          type: string
+          description: Calculated cut-off date and time.
+        payment_type:
+          type: string
+          description: Type of payment - priority (Swift) or regular (local).
+        currency:
+          type: string
+          description: The 3-letter ISO code for the currency of the payment.
+        bank_country:
+          type: string
+          description: Country in which the beneficiary's bank account is held. Two-letter ISO country code.
+      example:
+        payment_date: '2019-02-11'
+        payment_delivery_date: '2019-02-11T00:00:00+00:00'
+        payment_cutoff_time: '2019-02-11T19:00:00+00:00'
+        payment_type: priority
+        currency: MXN
+        bank_country: MX
+    PaymentFee:
+      type: object
+      description: Payment fee.
+      required:
+      - id
+      - name
+      - currency
+      - regular_amount
+      - priority_shared_amount
+      - priority_ours_amount
+      - owner_account_id
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: ID of the payment fee.
+        name:
+          type: string
+          description: Name of the payment fee.
+        currency:
+          type: string
+          description: The fee currency.
+        regular_amount:
+          type: string
+          description: The fee regular amount.
+        priority_shared_amount:
+          type: string
+          description: The fee priority shared amount.
+        priority_ours_amount:
+          type: string
+          description: The fee priority our amount.
+        owner_account_id:
+          type: string
+          format: uuid
+          description: The ID of the owner account.
+      example:
+        id: 49521d55-5dd8-4362-8c2d-03b02b1a714b
+        name: 1updfee_table_AUD4
+        currency: DKK
+        regular_amount: '50.00'
+        priority_shared_amount: '40.00'
+        priority_ours_amount: '30.00'
+        owner_account_id: null
+    PaymentFeeAssignment:
+      type: object
+      description: Payment Fee Assignment.
+      required:
+      - id
+      - account_id
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: ID of the payment fee.
+        account_id:
+          type: string
+          format: uuid
+          description: ID of the sub-account the rule is assigned to.
+      example:
+        id: a6c4a482-1a56-49ea-be55-b9b0bb92a9b2
+        account_id: 0178a7ba-9a77-4c74-af71-a5f650f00e09
+    PaymentFeeAssignmentError:
+      type: object
+      description: 'Client error information for the Payment Fee Assignment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    PaymentFeeRule:
+      type: object
+      description: Payment fee rule.
+      required:
+      - payment_type
+      - charge_type
+      - fee_amount
+      - fee_currency
+      - payment_fee_id
+      - payment_fee_name
+      additionalProperties: false
+      properties:
+        payment_type:
+          type: string
+          description: The payment type the fee is applicable to, priority(Swift) or regular(local).
+        charge_type:
+          type: string
+          description: The charge type the fee is applicable to.
+        fee_amount:
+          type: string
+          description: The fee amount.
+        fee_currency:
+          type: string
+          description: The fee currency.
+        payment_fee_id:
+          type: string
+          format: uuid
+          description: The ID of payment level rule.
+        payment_fee_name:
+          type: string
+          description: The name of payment level fee table.
+      example:
+        payment_type: priority
+        charge_type: shared
+        fee_amount: '2.00'
+        fee_currency: AED
+        payment_fee_id: 5c3b8754-406d-4e7e-a80e-606fa273ab80
+        payment_fee_name: fee_table_AED
+    PaymentPurposeCodes:
+      type: object
+      description: Payment purpose codes.
+      properties:
+        currency:
+          type: string
+          description: Payment currency
+        entity_type:
+          type: string
+          description: Legal entity type - 'company' or 'individual'.
+        purpose_code:
+          type: string
+          description: Purpose code
+        purpose_description:
+          type: string
+          description: A description of the purpose code.
+        bank_account_country:
+          type: string
+          description: Two-letter country code for the country of the bank account.
+      example:
+        currency: INR
+        entity_type: Company
+        purpose_code: delivery
+        purpose_description: Delivery fees for goods
+        bank_account_country: IN
+    PaymentFeeUnassignment:
+      type: object
+      description: Payment fee unassignment.
+      required:
+      - account_id
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+          format: uuid
+          description: ID of the sub-account the rule is assigned to.
+      example:
+        account_id: 0178a7ba-9a77-4c74-af71-a5f650f00e09
+    PaymentFeeUnassignmentError:
+      type: object
+      description: 'Client error information for the Payment Fee Unassignment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    PaymentConfirmation:
+      type: object
+      description: Payment confirmation.
+      properties:
+        id:
+          type: string
+          description: Unique ID of the Payment Confirmation.
+        payment_id:
+          type: string
+          description: Unique ID for the payment the confirmation relates to.
+        account_id:
+          type: string
+          description: Account ID
+        short_reference:
+          type: string
+          description: Short reference for the Payment Confirmation.
+        status:
+          type: string
+          description: Status of the Payment Confirmation processing.
+        confirmation_url:
+          type: string
+          description: URL to download Payment Confirmation file.
+        created_at:
+          type: string
+          format: date-time
+          description: Date and time of when the Payment Confirmation was created.
+        updated_at:
+          type: string
+          format: date-time
+          description: Date and time of when the Payment Confirmation was last updated.
+        expires_at:
+          type: string
+          format: date-time
+          description: Date and time of when the Payment Confirmation will expire.
+      example:
+        id: 123123121-91de-012f-e284-1e0030c7f3111
+        payment_id: 543477161-91de-012f-e284-1e0030c7f3123
+        account_id: 543477161-91de-012f-e284-1e0030c7f352
+        short_reference: 140416-GGJBNQ001
+        status: completed
+        confirmation_url: https://s3.com/140416-GGJBNQ001.pdf
+        created_at: '2014-01-12T00:00:00+00:00'
+        updated_at: '2014-01-12T00:00:00+00:00'
+        expires_at: '2014-02-12T00:00:00+00:00'
+    PaymentSubmissionInformation:
+      type: object
+      description: Payment submission.
+      properties:
+        status:
+          type: string
+          description: The status of the submission.
+          enum:
+          - canceled
+          - closed
+          - completed_manually
+          - duplicated
+          - failed
+          - pending
+          - processing
+          - success
+          - waiting_to_process
+        submission_ref:
+          type: string
+        format:
+          type: string
+          description: MT103 or PACS008
+        message:
+          type: string
+          description: The Swift message
+      example:
+        status: pending
+        submission_ref: MXGGYAGJULIIQKDV
+        format: PACS008
+        message: <AppHdr xmlns="urn:iso:std:iso:20022:tech:xsd:head.001.001.02"> ...
+    PaymentTrackingInfo:
+      type: object
+      description: PaymentTrackingInfo
+      required:
+      - uetr
+      - transaction_status
+      - initiation_time
+      - completion_time
+      - last_update_time
+      - payment_events
+      additionalProperties: false
+      properties:
+        uetr:
+          type: string
+          description: Unique End-to-end Transaction Reference.
+        transaction_status:
+          type: object
+          description: Status of the transaction.
+          required:
+          - status
+          - reason
+          properties:
+            status:
+              type: string
+              description: Current status
+            reason:
+              type: string
+              description: Reason for current status.
+        initiation_time:
+          type: string
+          format: date-time
+          description: Time of initiation.
+        completion_time:
+          type: string
+          format: date-time
+          description: Time of completion.
+        last_update_time:
+          type: string
+          format: date-time
+          description: Time of last update.
+        payment_events:
+          type: array
+          description: List of events that have been applied to the payment.
+          items:
+            type: object
+            description: An object describing an event that has been applied to the payment.
+      example:
+        uetr: 46ed4827-7b6f-4491-a06f-b548d5a7512d
+        transaction_status:
+          status: processing
+          reason: transferred_and_tracked
+        initiation_time: '2019-07-09T13:20:30.000Z'
+        completion_time: null
+        last_update_time: '2019-07-10T15:39:08.690Z'
+        payment_events:
+        - tracker_event_type: credit_transfer_payment_cancellation_request
+          valid: true
+          transaction_status: null
+          funds_available: null
+          forwarded_to_agent: null
+          from: BANABEBBXXX
+          to: BANAUS33XXX
+          originator: BANABEBBXXX
+          serial_parties: null
+          sender_acknowledgement_receipt: '2019-07-10T14:22:41.273Z'
+          instructed_amount: null
+          confirmed_amount: null
+          interbank_settlement_amount:
+            currency: USD
+            amount: 745437.57
+          interbank_settlement_date: '2019-07-09'
+          charge_type: null
+          charge_amount: null
+          foreign_exchange_details: null
+          last_update_time: '2019-07-10T14:22:41.273Z'
+        - tracker_event_type: customer_credit_transfer_payment
+          valid: true
+          transaction_status:
+            status: processing
+            reason: transferred_and_tracked
+          funds_available: null
+          forwarded_to_agent: null
+          from: BANABEBBXXX
+          to: BANAUS33XXX
+          originator: BANABEBBXXX
+          serial_parties:
+            debtor_agent: GPMRCH30
+            creditor_agent: GPMRQAJ0
+          sender_acknowledgement_receipt: '2019-07-09T13:20:30.000Z'
+          instructed_amount:
+            currency: USD
+            amount: 745437.57
+          confirmed_amount: null
+          interbank_settlement_amount:
+            currency: USD
+            amount: 745437.57
+          interbank_settlement_date: '2019-07-09'
+          charge_type: shared
+          charge_amount: null
+          foreign_exchange_details: null
+          last_update_time: '2019-07-09T13:20:50.633Z'
+    QuotePaymentFee:
+      type: object
+      description: Quote payment fee.
+      required:
+      - account_id
+      - payment_currency
+      - payment_destination_country
+      - payment_type
+      - charge_type
+      - fee_amount
+      - fee_currency
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+          description: Tha account Id.
+        payment_currency:
+          type: string
+          description: Three letter ISO code for the currency of the payment.
+        payment_destination_country:
+          type: string
+          description: Two-letter ISO country code for the payment's destination country.
+        payment_type:
+          type: string
+          description: The payment type the fee is applicable to, priority(Swift) or regular(local).
+        charge_type:
+          type: string
+          description: The charge type the fee is applicable.
+        fee_amount:
+          type: string
+          description: The fee amount.
+        fee_currency:
+          type: string
+          description: Three-letter ISO currency code for the fee's currency.
+      example:
+        account_id: 0534aaf2-2egg-0134-2f36-10b11cd33cfb
+        payment_currency: USD
+        payment_destination_country: US
+        payment_type: regular
+        charge_type: null
+        fee_amount: '10.00'
+        fee_currency: EUR
+    RatesBasic:
+      properties:
+        rates:
+          type: object
+          description: Maps currency pairs (eg. "EURUSD", "GBPZAR") to rates. The first number is the bid SPOT rate and the
+            second is the ask SPOT rate. For example, in the EURUSD example response, the first number (1.3803) is the EUR->USD
+            rate and the second number (1.3809) is the USD->EUR rate.
+          additionalProperties:
+            type: array
+            items:
+              type: string
+              description: A pair of rates for the currency pair. The first number is the bid SPOT rate and the second is
+                the ask SPOT rate.
+        unavailable:
+          type: array
+          description: A list of valid currency pairs that are not currently available.
+          items:
+            type: string
+      example:
+        EURUSD:
+        - '1.3803'
+        - '1.3809'
+        GBPZAR:
+        - '17.5271'
+        - '17.5279'
+    RateDetailed:
+      type: object
+      description: Detailed rate information.
+      properties:
+        settlement_cut_off_time:
+          description: The date and time by which funds need to be available to settle the trade, in the format YYYY-MM-DDThh:mm:ssZ
+          type: string
+        currency_pair:
+          description: Concatenated string of the two currencies traded, e.g. "USDEUR".
+          type: string
+        client_buy_currency:
+          description: Three character ISO code for the currency being bought.
+          type: string
+        client_sell_currency:
+          description: Three character ISO code for the currency being sold.
+          type: string
+        client_buy_amount:
+          description: The amount of buy currency for a client.
+          type: string
+        client_sell_amount:
+          description: The amount of sell currency for a client.
+          type: string
+        fixed_side:
+          description: Which currency is fixed -  the buy or sell one.
+          type: string
+          enum:
+          - buy
+          - sell
+        mid_market_rate:
+          description: The mid point between buy and sell rates.
+          type: string
+        core_rate:
+          description: The market rate.
+          type: string
+        partner_rate:
+          description: The market rate + Currencycloud's commission (if applicable).
+          type: string
+        client_rate:
+          description: The rate that will be returned to your customer after all spread has been applied.
+          type: string
+        deposit_required:
+          description: Is a deposit required for the conversion?
+          type: string
+        deposit_amount:
+          description: The amount of a deposit required.
+          type: string
+        deposit_currency:
+          description: Three-letter ISO currency code for the currency the deposit is shown in.
+          type: string
+      example:
+        settlement_cut_off_time: '2023-12-31T23:59:59.000Z'
+        currency_pair: GBPUSD
+        client_buy_currency: GBP
+        client_sell_currency: USD
+        client_buy_amount: '1000.00'
+        client_sell_amount: '1594.90'
+        fixed_side: buy
+        mid_market_rate: '1.5868'
+        core_rate: '1.587'
+        partner_rate: '1.5878'
+        client_rate: '1.5949'
+        deposit_required: 'true'
+        deposit_amount: '316.96'
+        deposit_currency: USD
+    RateLimitError:
+      type: object
+      description: Too many requests.
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this validation/error.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    Sender:
+      type: object
+      description: Sender
+      properties:
+        id:
+          type: string
+          description: The unique UUID for the Sender.
+        amount:
+          type: string
+          description: The transaction amount.
+        currency:
+          type: string
+          description: Three-letter ISO currency code for the transaction's currency.
+        additional_information:
+          type: string
+          description: Any additional information for the transaction, e.g. addtional sender details or transaction and client
+            references.
+        value_date:
+          type: string
+          description: The transaction value date.
+          format: date-time
+        sender:
+          type: string
+          description: Sender details - the format is "sender":"name; address; country; account_number or iban; bic; routing_code"
+        receiving_account_number:
+          type: string
+          description: The account number that received the funds.
+        receiving_account_iban:
+          type: string
+          description: The IBAN number for the account that received the funds.
+        created_at:
+          type: string
+          description: The transaction date and time of creation.
+          format: date-time
+        updated_at:
+          type: string
+          description: The transaction date and time of the last update.
+          format: date-time
+      example:
+        id: 21a7edce-fff8-486a-ac28-0dd143375081
+        amount: '450.00'
+        currency_code: GBP
+        free_text: 6320260731508339645906       0000045000TEST NAME      THE CURRENCY CLOUD    S 0063106146268242
+        value_date: '2018-03-27T00:00:00.000Z'
+        sender: CITIBANK XFER, POPMONEY
+        source_account_number: 8119645406
+        source_account_iban: null
+        credit_debit: debit
+        created_at: '2018-03-27T10:51:32.000Z'
+        updated_at: '2018-03-27T10:51:34.000Z'
+    SenderInformation:
+      description: The sender information
+      properties:
+        sender_account_number:
+          description: The sender account number
+          type: string
+        sender_address:
+          description: The unstructured sender address
+          type: string
+        sender_bic:
+          description: The sender bic
+          type: string
+        sender_country:
+          description: The two letter sender country
+          type: string
+        sender_iban:
+          description: The sender iban
+          type: string
+        sender_id:
+          description: The sender id
+          type: string
+        sender_name:
+          description: The sender name
+          type: string
+        sender_routing_code:
+          description: The sender routing code
+          type: string
+      example:
+        sender_account_number: 8119645406
+        sender_address: Some street
+        sender_bic: null
+        sender_country: GB
+        sender_iban: null
+        sender_id: 5c675fa4-fdf0-4ee6-b5bb-156b36765433
+        sender_name: Test sender
+        sender_routing_code: null
+      type: object
+    SettlementAccount:
+      type: object
+      description: Settlement accounts.
+      properties:
+        bank_account_holder_name:
+          type: string
+          description: The bank account holder's name.
+        beneficiary_address:
+          type: array
+          description: The beneficiary's address.
+          items:
+            type: string
+            description: Line of address.
+        beneficiary_country:
+          description: Beneficiary's country.
+          type: string
+        bank_name:
+          description: The name of the bank.
+          type: string
+        bank_address:
+          description: The bank's address.
+          type: array
+          items:
+            type: string
+            description: Line of address
+        bank_country:
+          type: string
+          description: Two-letter ISO country code for the bank's country.
+        currency:
+          description: Payment currency
+          type: string
+        bic_swift:
+          description: BIC / Swift code
+          type: string
+        iban:
+          description: IBAN number
+          type: string
+        account_number:
+          description: Account number
+          type: string
+        routing_code_type_1:
+          description: Routing system for regular (local) payments.
+          type: string
+          enum:
+          - aba
+          - bank_code
+          - branch_code
+          - bsb_code
+          - clabe
+          - cnaps
+          - ifsc
+          - institution_no
+          - sort_code
+        routing_code_value_1:
+          type: string
+          description: Value for routing system 'routing_code_type_1'.
+        routing_code_type_2:
+          type: string
+          enum:
+          - aba
+          - bank_code
+          - branch_code
+          - bsb_code
+          - clabe
+          - cnaps
+          - ifsc
+          - institution_no
+          - sort_code
+          description: Local payment routing system.
+        routing_code_value_2:
+          type: string
+          description: Value for routing system 'routing_code_type_2'.
+      example:
+        bank_account_holder_name: The Currency Cloud GBP - Client Seg A/C
+        beneficiary_address:
+        - 1 Churchill Place London E14 5HP
+        beneficiary_country: GB
+        bank_name: Barclays Bank Plc.
+        bank_address:
+        - 164 Bishopsgate London EC2M 4LX
+        bank_country: GB
+        currency: GBP
+        bic_swift: BARCGB22
+        iban: GB33 BUKB 2020 1555 5555 55
+        account_number: '13071472'
+        routing_code_type_1: sort_code
+        routing_code_value_1: '200605'
+        routing_code_type_2: ''
+        routing_code_value_2: ''
+    TopUpMarginBalance:
+      type: object
+      description: Bank Details.
+      required:
+      - account_id
+      - currency
+      - transferred_amount
+      additionalProperties: false
+      properties:
+        account_id:
+          type: string
+          description: Account identifier
+        currency:
+          type: string
+          description: Currency code for currency transferred.
+        transferred_amount:
+          type: string
+          description: Amount of transfer.
+      example:
+        account_id: 6c046c51-2387-4004-8e87-4bf97102e36d
+        currency: EUR
+        transferred_amount: 100.0
+    TopUpMarginBalanceError:
+      type: object
+      description: 'Client error information for the Top Up Margin Balance endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    Transaction:
+      type: object
+      description: Transaction.
+      properties:
+        id:
+          type: string
+          description: Transaction ID
+        balance_id:
+          type: string
+          description: Balance ID
+        account_id:
+          type: string
+          description: Account ID
+        currency:
+          type: string
+          description: Three-letter ISO currency code.
+        amount:
+          type: string
+          description: Transaction amount
+        balance_amount:
+          type: string
+          description: Balance amount
+        type:
+          type: string
+          description: Type (debit or credit).
+          enum:
+          - credit
+          - debit
+        action:
+          type: string
+          description: The action that triggered the transaction.
+          enum:
+          - conversion
+          - conversion_deposit
+          - deposit_refund
+          - funding
+          - margin
+          - manual_transaction
+          - payment
+          - payment_failure
+          - payment_fee
+          - payment_unrelease
+          - transfer
+        related_entity_type:
+          type: string
+          description: The related entity type.
+          enum:
+          - balance_transfer
+          - conversion
+          - deposit
+          - inbound_funds
+          - margin_transaction
+          - payment
+        related_entity_id:
+          type: string
+        related_entity_short_reference:
+          type: string
+          description: Releated entity short reference.
+        status:
+          type: string
+          description: Transaction status
+          enum:
+          - completed
+          - deleted
+          - pending
+        reason:
+          description: Reason
+          type: string
+        settles_at:
+          description: Settlement date
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          description: Date the transaction record was created.
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          description: Date the transaction record was last updated.
+          format: date-time
+      example:
+        id: c5a990eb-d4d7-482f-bfb1-695261fb1e4d
+        balance_id: c5f1f54e-d6d8-4140-8110-f5b99bbc80c3
+        account_id: 7b9757a8-eee9-4572-86e6-77f4d711eaa6
+        currency: USD
+        amount: '1000.00'
+        balance_amount: '2000.00'
+        type: credit
+        action: conversion
+        related_entity_type: conversion
+        related_entity_id: e93e322f-93aa-4d31-b050-449da723db0b
+        related_entity_short_reference: 140416-GGJBNQ001
+        status: completed
+        reason: Reason for Transaction
+        settles_at: '2023-12-31T23:59:59.000Z'
+        created_at: '2023-12-31T23:59:59.000Z'
+        updated_at: '2023-12-31T23:59:59.000Z'
+        completed_at: '2023-12-31T23:59:59.000Z'
+    Transfer:
+      type: object
+      description: Transfer
+      properties:
+        id:
+          type: string
+          description: Transfer UUID
+        short_reference:
+          type: string
+          description: Short reference code.
+        source_account_id:
+          type: string
+          description: Account UUID of the paying account.
+        destination_account_id:
+          type: string
+          description: Account UUID of the receiving account.
+        currency:
+          type: string
+          description: Three-letter ISO currency code.
+        amount:
+          type: string
+          description: Transfer amount
+        status:
+          type: string
+          description: Status of the transfer - completed, pending or cancelled.
+        created_at:
+          type: string
+          description: Date/time the transfer was created.
+        updated_at:
+          type: string
+          description: Date/time the transfer was last updated.
+        completed_at:
+          type: string
+          description: Date/time the transfer was completed.
+        creator_account_id:
+          type: string
+          description: Account UUID of transfer instructor.
+        creator_contact_id:
+          type: string
+          description: Contact UUID of transfer instructor.
+        reason:
+          type: string
+          description: Reason for the transfer.
+        unique_request_id:
+          type: string
+          description: The user-generated idempotency key given to the transfer.
+      example:
+        id: 993d63bd-e151-11e6-a5af-080027a79e8f
+        short_reference: BT-20200118-VMSCBS
+        source_account_id: a7117404-e150-11e6-a5af-080027a79e8f
+        destination_account_id: 946f2d58-e150-11e6-a5af-080027a79e8f
+        currency: GBP
+        amount: '1250.00'
+        status: completed
+        created_at: '2023-01-18T14:08:34.000Z'
+        updated_at: '2023-01-18T14:08:34.000Z'
+        completed_at: '2023-01-18T14:08:34.000Z'
+        creator_account_id: 30cb8632-e152-11e6-a5af-080027a79e8f
+        creator_contact_id: 262e3d2a-e152-11e6-a5af-080027a79e8f
+        reason: Director's fees for March
+        unique_request_id: 1234567890abc
+    UnauthorizedError:
+      type: object
+      description: Authorization error.
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+          enum:
+          - auth_failed
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+      example:
+        error_code: auth_failed
+        error_messages:
+          api_key:
+          - code: invalid_supplied_credentials
+            message: Authentication failed with the supplied credentials
+            params: {}
+    UpdateAccountError:
+      type: object
+      description: 'Client error information for the Update Account endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    UpdateBeneficiaryError:
+      type: object
+      description: 'Client error information for the Update Beneficiary endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    UpdateContactError:
+      type: object
+      description: 'Client error information for the Update Contact endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    UpdatePaymentError:
+      type: object
+      description: 'Client error information for the Update Payment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    ValidateBeneficiaryError:
+      type: object
+      description: 'Client error information for the Validate Beneficiary endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    BeneficiaryAccountVerificationError:
+      type: object
+      description: 'Client error information for the Beneficiary Account Verification (CoP) endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    ValidatePaymentError:
+      type: object
+      description: 'Client error information for the Validate Payment endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    RetryNotificationError:
+      type: object
+      description: Client error information for the retry payment notification endpoint.
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for  input parameters that failed validation. Object keys are the names
+            of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    ForbiddenError:
+      type: object
+      description: Permission error.
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+          enum:
+          - auth_failed
+        error_messages:
+          type: object
+          description: Detailed error information on what permissions are missing so that the request could not be fulfilled
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents the reasons why the request was not permitted.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    WithdrawalAccount:
+      type: object
+      description: Withdrawal account
+      required:
+      - id
+      - account_name
+      - account_holder_name
+      - account_holder_dob
+      - routing_code
+      - account_number
+      - currency
+      - account_id
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: The UUID of the withdrawal account.
+        account_name:
+          type: string
+          description: The name of the withdrawal account.
+        account_holder_name:
+          type: string
+          description: The name of the withdrawal account holder.
+        account_holder_dob:
+          type: string
+          format: date
+          description: The DOB of the withdrawal account holder.
+        routing_code:
+          type: string
+          description: The routing code of the withdrawal account.
+        account_number:
+          type: string
+          description: The account number of the withdrawal account.
+        currency:
+          type: string
+          description: The currency of the withdrawal account.
+        account_id:
+          type: string
+          description: The UUID of the CurrencyCloud account the withdrawal account is linked to.
+      example:
+        id: ffb9fdea-312b-4bc8-beb9-5e44ee2d2a8c
+        account_name: TestAccount
+        account_holder_name: John Smith
+        account_holder_dob: '1987-05-12'
+        routing_code: 987654321
+        account_number: 0123456789
+        currency: USD
+        account_id: 82214b7e-9192-4d9e-82cf-e2c4b1670f23
+    WithdrawalPullFundsRequestDetails:
+      type: object
+      description: Details of a Withdrawal Pull Request.
+      required:
+      - id
+      - withdrawal_account_id
+      - reference
+      - amount
+      - created_at
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: The ID for the Pull Request.
+        withdrawal_account_id:
+          type: string
+          description: The ID of the withdrawal account to pull funds from.
+        reference:
+          type: string
+          description: The reference provided at the time the request was made.
+        amount:
+          type: string
+          description: The amount to be pulled from the withdrawal account.
+        created_at:
+          type: string
+          format: date-time
+          description: Date the pull funds request record was created.
+      example:
+        id: 82214b7e-9192-4d9e-82cf-e2c4b1670f23
+        withdrawal_account_id: ffb9fdea-312b-4bc8-beb9-5e44ee2d2a8c
+        reference: Reference
+        amount: 1000.0
+        created_at: '2019-04-18T08:17:22+00:00'
+    WithdrawalPullFundsRequestError:
+      type: object
+      description: 'Client error information for the Post WithdrawalAccount PullFunds endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255
+    SimulateFunding:
+      type: object
+      description: SimulateFunding
+      required:
+      - id
+      - account_id
+      - state
+      - sender_name
+      - sender_address
+      - sender_country
+      - sender_reference
+      - sender_account_number
+      - sender_routing_code
+      - receiver_account_number
+      - receiver_routing_code
+      - amount
+      - currency
+      - action
+      - short_reference
+      - updated_at
+      - created_at
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          description: The unique UUID for the simulated fund.
+        account_id:
+          type: string
+          description: The account UUID the simulated fund was created for.
+        state:
+          type: string
+          description: The state of the simulated fund.
+        sender_name:
+          type: string
+          description: The sender's name.
+        sender_address:
+          type: string
+          description: The sender's address.
+        sender_country:
+          type: string
+          description: Two-digit sender country.
+        sender_reference:
+          type: string
+          description: Sender reference.
+        sender_account_number:
+          type: string
+          description: Sender account number.
+        sender_routing_code:
+          type: string
+          description: Sender routing code.
+        receiver_account_number:
+          type: string
+          description: A client or its sub-account's account number.
+        receiver_routing_code:
+          type: string
+          description: Routing code for a client or its sub-account.
+        amount:
+          type: string
+          description: Amount of the emulated transaction.
+        currency:
+          type: string
+          description: Three-digit currency code.
+        action:
+          type: string
+          description: Allows you to trigger approval or rejection behaviour.
+          enum:
+          - approve
+          - reject
+        short_reference:
+          type: string
+          description: The reference generated by the system to identify the fund.
+        created_at:
+          type: string
+          description: The date-time the SSI was added to the account.
+          format: date-time
+        updated_at:
+          type: string
+          description: The date-time the SSI was last updated on the account.
+          format: date-time
+      example:
+        id: 2090939e-b2f7-3f2b-1363-jfy28d74kc72
+        account_id: 2090939e-b2f7-3f2b-1363-4d235b3f58af
+        state: pending
+        sender_name: Mr. Sender
+        sender_address: Some Street
+        sender_country: GB
+        sender_reference: sender-ref"
+        sender_account_number: 22223333
+        sender_routing_code: 222333
+        receiver_account_number: 22213332
+        receiver_routing_code: 776813
+        amount: '150.53'
+        currency: GBP
+        action: reject
+        short_reference: REF-22122
+        created_at: '2018-05-14T14:18:30+00:00'
+        updated_at: '2018-05-14T14:18:30+00:00'
+    CreateSimulateFundingError:
+      type: object
+      description: 'Client error information for the Create Simulated Funding endpoint.
+
+        '
+      required:
+      - error_code
+      - error_messages
+      properties:
+        error_code:
+          type: string
+          description: A high-level error code for the whole request.
+        error_messages:
+          type: object
+          description: Detailed error information for individual input parameters that failed validation. Object keys are
+            the names of the invalid input parameters. Each parameter may have one or more reasons why it failed.
+          additionalProperties:
+            type: array
+            items:
+              type: object
+              description: An object that represents one of the reasons why the input parameter failed.
+              required:
+              - code
+              - message
+              properties:
+                code:
+                  type: string
+                  description: A unique code that identifies this error. It can be used for translations.
+                message:
+                  type: string
+                  description: An explanation of the error in English.
+                params:
+                  type: object
+                  default: {}
+                  description: Relevant validation rules that failed. This can be used for translations.
+                  example:
+                    minlength: 1
+                    maxlength: 255

--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -87,7 +87,7 @@ schemes:
 host: devapi.currencycloud.com
 basePath: /v2
 consumes:
-  - multipart/form-data
+  - application/x-www-form-urlencoded
 produces:
   - application/json
 paths:
@@ -116,7 +116,7 @@ paths:
         reactivate their account.
       operationId: Login
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -235,7 +235,7 @@ paths:
         to time out.
       operationId: Logout
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -325,7 +325,7 @@ paths:
       description: 'Creates a new sub-account. Returns the new account entity on success.'
       operationId: CreateAccount
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -835,523 +835,523 @@ paths:
               type: string
               description: A unique reference for the request.
   /accounts/{id}:
-   get:
-    tags:
-      - Accounts
-    x-api-group: manage
-    summary: Get Account
-    description: Gets an account or sub-account owned by the authenticated user.
-    operationId: GetAccount
-    produces:
-      - application/json
-    parameters:
-      - name: X-Auth-Token
-        in: header
-        required: true
-        type: string
-        description: Authentication token
-      - name: id
-        in: path
-        required: true
-        type: string
-        description: Account UUID, returned by the create account endpoint.
-      - name: on_behalf_of
-        in: query
-        required: false
-        type: string
-        description: A contact UUID for the sub-account you're acting on behalf of.
-    responses:
-      '200':
-        description: Success.
-        schema:
-          $ref: '#/definitions/Account'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '400':
-        description: Client error.
-        x-errors:
-          - code: id_is_not_valid_uuid
-            category: id
-            message: id should be in UUID format
-            params: ''
-          - code: account_not_found
-            category: id
-            message: Account was not found for this id
-            params: ''
-          - code: on_behalf_of_self
-            category: on_behalf_of
-            message: You cannot act on behalf of your own contact
-            params: ''
-          - code: contact_not_found
-            category: on_behalf_of
-            message: Contact was not found for this id
-            params: ''
-        schema:
-          $ref: '#/definitions/GetAccountError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '401':
-        description: Unauthorized
-        x-errors:
-          - code: invalid_supplied_credentials
-            category: username
-            message: Authentication failed with the supplied credentials
-            params: ''
-        schema:
-          $ref: '#/definitions/UnauthorizedError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '404':
-        description: Resource not found.
-        schema:
-          $ref: '#/definitions/NotFoundError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '429':
-        description: Too many requests.
-        x-errors:
-          - code: too_many_requests
-            category: base
-            message: >-
-              Too many requests have been made to the api. Please refer to the
-              Developer Center for more information
-            params: ''
-        schema:
-          $ref: '#/definitions/RateLimitError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '500':
-        description: Internal server error
-        x-errors:
-          - code: internal_server_error
-            category: base
-            message: Internal server error
-            params: ''
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '503':
-        description: Service is temporary unavailable.
-        x-errors:
-          - code: service_unavailable
-            category: base
-            message: Service is temporarily unavailable
-            params: ''
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      default:
-        description: Unexpected error.
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-   post:
-    tags:
-      - Accounts
-    x-api-group: manage
-    summary: Update Account
-    description: >-
-      Updates a sub-account owned by the authenticated user. The updated account entity is returned on success.
-    operationId: UpdateAccount
-    consumes:
-      - multipart/form-data
-    produces:
-      - application/json
-    parameters:
-      - name: X-Auth-Token
-        in: header
-        required: true
-        type: string
-        description: Authentication token
-      - name: id
-        in: path
-        required: true
-        type: string
-        description: Account UUID, returned by the create account endpoint.
-      - name: account_name
-        in: formData
-        required: false
-        type: string
-        description: Account name.
-      - name: legal_entity_type
-        in: formData
-        required: false
-        type: string
-        enum:
-          - company
-          - individual
-        description: Legal entity.
-      - name: brand
-        in: formData
-        required: false
-        type: string
-        description: >-
-          The value of this field is used for white labeling the Currencycloud
-          user interface.
-      - name: your_reference
-        in: formData
-        required: false
-        type: string
-        description: User-generated reference code.
-      - name: status
-        in: formData
-        required: false
-        type: string
-        enum:
-          - disabled
-          - enabled
-          - enabled_no_trading
-        default: enabled
-        description: Status of the account.
-      - name: street
-        in: formData
-        required: false
-        type: string
-        description: First line of address.
-      - name: city
-        in: formData
-        required: false
-        type: string
-        description: City name
-      - name: state_or_province
-        in: formData
-        required: false
-        type: string
-        description: State or province two-letter ISO 3166 code. Only applicable to some countries.
-      - name: postal_code
-        in: formData
-        required: false
-        type: string
-        description: Postal code.
-      - name: country
-        in: formData
-        required: false
-        type: string
-        description: Two-letter ISO country code.
-      - name: spread_table
-        in: formData
-        required: false
-        type: string
-        default: fxcg_rfx_default
-        description: The name of the spread table assigned to the account.
-      - name: api_trading
-        in: formData
-        required: false
-        type: boolean
-        default: true
-        description: >-
-          Whether trading via the Currencycloud API is to be enabled on the
-          account.
-      - name: online_trading
-        in: formData
-        required: false
-        type: boolean
-        default: true
-        description: Enable online trading on the account.
-      - name: phone_trading
-        in: formData
-        required: false
-        default: true
-        type: boolean
-        description: Enable phone trading on the account.
-      - name: identification_type
-        in: formData
-        required: false
-        type: string
-        enum:
-          - none
-          - others
-          - asylum_registration_card
-          - citizenship_papers
-          - consular_id
-          - credential_de_elector
-          - drivers_license
-          - drivers_license_canadian
-          - employer_identification_number
-          - existing_credit_card_details
-          - green_card
-          - immigration_status_document
-          - indigenous_card
-          - international_driving_licence
-          - matricula_consular
-          - municipality_identity_card
-          - national_health_insurance_card
-          - national_id
-          - national_identity_card
-          - passport
-          - passport_card
-          - postal_identity_card
-          - private_operators_card
-          - professional_qualification_card
-          - proof_of_citizenship
-          - registro_federal_de_contribuyentes
-          - residence_permit
-          - residence_status_document
-          - service_id_card
-          - social_insurance_number
-          - social_security_card
-          - social_security_number
-          - tax_id
-          - visa
-          - voter_id
-          - work_permit
-          - incorporation_number
-        description: A legal document that verifies the identity of the account owner.
-      - name: identification_value
-        in: formData
-        required: false
-        type: string
-        description: >-
-          A unique reference code for the identification document, such as a
-          passport number.
-        maxLength: 255
-      - name: terms_and_conditions_accepted
-        in: formData
-        required: false
-        type: boolean
-        description: Acceptance of the terms and conditions.
-      - name: identification_expiration
-        in: formData
-        required: false
-        type: string
-        format: date
-        description: >-
-          The expiration date for the identification information provided. Format YYYY-MM-DD. Part of extended compliance for "legal_entity_type: individual" accounts.
-      - name: identification_issuer
-        in: formData
-        required: false
-        type: string
-        maxLength: 255
-        description: >-
-          ISO country code indicating the issuer of the identification information provided. Part of extended compliance for "legal_entity_type: individual" accounts.
-      - name: legal_entity_sub_type
-        in: formData
-        required: false
-        type: string
-        description: >-
-          The type of company this account represents. Part of extended compliance for "legal_entity_type: company" accounts
-        enum:
-          - sole_trader
-          - limited_liability_company
-          - public_limited_company
-          - limited_liability_partnership
-          - unincorporated_partnership
-          - unregistered_charity
-          - registered_charity
-          - trust
-          - company_with_nominee_shareholders_or_shares_in_bearer_form
-          - scottish_limited_partnership
-          - other
-    responses:
-      '200':
-        description: Success.
-        schema:
-          $ref: '#/definitions/Account'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '400':
-        description: Client error.
-        x-errors:
-          - code: at_least_one_parameter
-            category: base
-            message: >-
-              At least one parameter should be present: account_name, brand,
-              your_reference, status, street, city, state_or_province, postal_code,
-              country, spread_table, legal_entity_type, identification_type,
-              identification_value, api_trading, online_trading, phone_trading
-              or terms_and_conditions_accepted.
-            params: '{ account_name, brand, your_reference, status, street, city, state_or_province, postal_code, country, spread_table, legal_entity_type, identification_type, identification_value, api_trading, online_trading, phone_trading, terms_and_conditions_accepted }'
-          - code: id_is_not_valid_uuid
-            category: id
-            message: id should be in UUID format
-            params: ''
-          - code: account_name_is_too_short
-            category: account_name
-            message: account_name can not be shorter than 1 character(s)
-            params: '{ "minlength" => 1}'
-          - code: account_name_is_too_long
-            category: account_name
-            message: account_name can not be longer than 150 character(s)
-            params: '{ "maxlength" => 150 }'
-          - code: account_name_is_in_invalid_format
-            category: account_name
-            message: account_name is in invalid format
-            params: ''
-          - code: brand_is_too_long
-            category: brand
-            message: brand can not be longer than 255 character(s)
-            params: '{ "maxlength" => 255 }'
-          - code: brand_not_found
-            category: brand
-            message: Brand non_existing_brand wasn't found
-            params: '{ "brand" => "non_existing_brand" }'
-          - code: brand_account_not_broker
-            category: brand
-            message: Account doesn't have broker permissions
-            params: '{ "brand" => "wrong_brand" }'
-          - code: permission_denied
-            category: permissions
-            message: Permission denied
-            params: ''
-          - code: your_reference_is_too_long
-            category: your_reference
-            message: your_reference can not be longer than 25 character(s)
-            params: '{ "maxlength" => 25 }'
-          - code: legal_entity_type_not_in_range
-            category: legal_entity_type
-            message: 'legal_entity_type should be in range: individual, company'
-            params: '{ "range" => "individual, company" }'
-          - code: status_not_in_range
-            category: status
-            message: 'status should be in range: enabled, disabled, enabled_no_trading'
-            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
-          - code: street_is_too_long
-            category: street
-            message: street can not be longer than 150 character(s)
-            params: '{ "maxlength" => 150 }'
-          - code: city_is_too_long
-            category: city
-            message: city can not be longer than 100 character(s)
-            params: '{ "maxlength" => 100 }'
-          - code: postal_code_is_too_long
-            category: postal_code
-            message: postal_code can not be longer than 20 character(s)
-            params: '{ "maxlength" => 20 }'
-          - code: state_or_province_is_too_long
-            category: state_or_province
-            message: state_or_province can not be longer than 100 character(s)
-            params: '{ "maxlength" => 100 }'
-          - code: country_is_in_invalid_format
-            category: country
-            message: country is not a valid ISO 3166-1 Alpha-2 country code
-            params: '{ "type" => "country_code" }'
-          - code: spread_table_is_too_long
-            category: spread_table
-            message: spread_table can not be longer than 100 character(s)
-            params: '{ "maxlength" => 100 }'
-          - code: identification_type_is_missing
-            category: identification_type
-            message: identification_type is missing
-            params: ''
-          - code: identification_type_not_in_range
-            category: identification_type
-            message: >-
-              identification_type should be in range: none, drivers_license,
-              social_security_number, green_card, passport, visa, matricula_consular,
-              registro_federal_de_contribuyentes, credential_de_elector,
-              social_insurance_number, citizenship_papers, drivers_license_canadian,
-              existing_credit_card_details, employer_identification_number, national_id,
-              others, incorporation_number, clave_unica_de_registro_de_poblacion
-            params: '{ "range": "none, drivers_license, social_security_number, green_card, passport, visa, matricula_consular, registro_federal_de_contribuyentes, credential_de_elector, social_insurance_number, citizenship_papers, drivers_license_canadian, existing_credit_card_details, employer_identification_number, national_id, others, incorporation_number, clave_unica_de_registro_de_poblacion" }'
-          - code: identification_type_is_invalid
-            category: identification_type
-            message: identification_type is invalid
-            params: ''
-          - code: identification_value_is_missing
-            message: identification_value is missing
-            category: identification_value
-            params: ''
-          - code: identification_value_is_invalid
-            category: identification_value
-            message: identification_value is invalid
-            params: ''
-          - code: identification_value_is_too_short
-            category: identification_value
-            message: identification_value can not be shorter than 1 character(s)
-            params: ' { "minlength": 1 }'
-          - code: editing_address_not_allowed
-            category: address
-            message: You cannot edit address information. Please contact support for additional information
-            params: ''
-          - code: editing_country_not_allowed
-            category: country
-            message: You cannot edit country. Please contact support for additional information
-            params: ''
-        schema:
-          $ref: '#/definitions/UpdateAccountError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '401':
-        description: Unauthorized.
-        x-errors:
-          - code: invalid_supplied_credentials
-            category: username
-            message: Authentication failed with the supplied credentials
-            params: ''
-        schema:
-          $ref: '#/definitions/UnauthorizedError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '404':
-        description: Resource not found.
-        schema:
-          $ref: '#/definitions/NotFoundError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '429':
-        description: Too many requests.
-        x-errors:
-          - code: too_many_requests
-            category: base
-            message: >-
-              Too many requests have been made to the api. Please refer to the
-              Developer Center for more information
-            params: ''
-        schema:
-          $ref: '#/definitions/RateLimitError'
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '500':
-        description: Internal server error
-        x-errors:
-          - code: internal_server_error
-            category: base
-            message: Internal server error
-            params: ''
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      '503':
-        description: Service is temporary unavailable
-        x-errors:
-          - code: service_unavailable
-            category: base
-            message: Service is temporarily unavailable
-            params: ''
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
-      default:
-        description: Unexpected error.
-        headers:
-          X-Request-Id:
-            type: string
-            description: A unique reference for the request.
+    get:
+      tags:
+        - Accounts
+      x-api-group: manage
+      summary: Get Account
+      description: Gets an account or sub-account owned by the authenticated user.
+      operationId: GetAccount
+      produces:
+        - application/json
+      parameters:
+        - name: X-Auth-Token
+          in: header
+          required: true
+          type: string
+          description: Authentication token
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: Account UUID, returned by the create account endpoint.
+        - name: on_behalf_of
+          in: query
+          required: false
+          type: string
+          description: A contact UUID for the sub-account you're acting on behalf of.
+      responses:
+        '200':
+          description: Success.
+          schema:
+            $ref: '#/definitions/Account'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '400':
+          description: Client error.
+          x-errors:
+            - code: id_is_not_valid_uuid
+              category: id
+              message: id should be in UUID format
+              params: ''
+            - code: account_not_found
+              category: id
+              message: Account was not found for this id
+              params: ''
+            - code: on_behalf_of_self
+              category: on_behalf_of
+              message: You cannot act on behalf of your own contact
+              params: ''
+            - code: contact_not_found
+              category: on_behalf_of
+              message: Contact was not found for this id
+              params: ''
+          schema:
+            $ref: '#/definitions/GetAccountError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '401':
+          description: Unauthorized
+          x-errors:
+            - code: invalid_supplied_credentials
+              category: username
+              message: Authentication failed with the supplied credentials
+              params: ''
+          schema:
+            $ref: '#/definitions/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '404':
+          description: Resource not found.
+          schema:
+            $ref: '#/definitions/NotFoundError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '429':
+          description: Too many requests.
+          x-errors:
+            - code: too_many_requests
+              category: base
+              message: >-
+                Too many requests have been made to the api. Please refer to the
+                Developer Center for more information
+              params: ''
+          schema:
+            $ref: '#/definitions/RateLimitError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '500':
+          description: Internal server error
+          x-errors:
+            - code: internal_server_error
+              category: base
+              message: Internal server error
+              params: ''
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '503':
+          description: Service is temporary unavailable.
+          x-errors:
+            - code: service_unavailable
+              category: base
+              message: Service is temporarily unavailable
+              params: ''
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+    post:
+      tags:
+        - Accounts
+      x-api-group: manage
+      summary: Update Account
+      description: >-
+        Updates a sub-account owned by the authenticated user. The updated account entity is returned on success.
+      operationId: UpdateAccount
+      consumes:
+        - application/x-www-form-urlencoded
+      produces:
+        - application/json
+      parameters:
+        - name: X-Auth-Token
+          in: header
+          required: true
+          type: string
+          description: Authentication token
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: Account UUID, returned by the create account endpoint.
+        - name: account_name
+          in: formData
+          required: false
+          type: string
+          description: Account name.
+        - name: legal_entity_type
+          in: formData
+          required: false
+          type: string
+          enum:
+            - company
+            - individual
+          description: Legal entity.
+        - name: brand
+          in: formData
+          required: false
+          type: string
+          description: >-
+            The value of this field is used for white labeling the Currencycloud
+            user interface.
+        - name: your_reference
+          in: formData
+          required: false
+          type: string
+          description: User-generated reference code.
+        - name: status
+          in: formData
+          required: false
+          type: string
+          enum:
+            - disabled
+            - enabled
+            - enabled_no_trading
+          default: enabled
+          description: Status of the account.
+        - name: street
+          in: formData
+          required: false
+          type: string
+          description: First line of address.
+        - name: city
+          in: formData
+          required: false
+          type: string
+          description: City name
+        - name: state_or_province
+          in: formData
+          required: false
+          type: string
+          description: State or province two-letter ISO 3166 code. Only applicable to some countries.
+        - name: postal_code
+          in: formData
+          required: false
+          type: string
+          description: Postal code.
+        - name: country
+          in: formData
+          required: false
+          type: string
+          description: Two-letter ISO country code.
+        - name: spread_table
+          in: formData
+          required: false
+          type: string
+          default: fxcg_rfx_default
+          description: The name of the spread table assigned to the account.
+        - name: api_trading
+          in: formData
+          required: false
+          type: boolean
+          default: true
+          description: >-
+            Whether trading via the Currencycloud API is to be enabled on the
+            account.
+        - name: online_trading
+          in: formData
+          required: false
+          type: boolean
+          default: true
+          description: Enable online trading on the account.
+        - name: phone_trading
+          in: formData
+          required: false
+          default: true
+          type: boolean
+          description: Enable phone trading on the account.
+        - name: identification_type
+          in: formData
+          required: false
+          type: string
+          enum:
+            - none
+            - others
+            - asylum_registration_card
+            - citizenship_papers
+            - consular_id
+            - credential_de_elector
+            - drivers_license
+            - drivers_license_canadian
+            - employer_identification_number
+            - existing_credit_card_details
+            - green_card
+            - immigration_status_document
+            - indigenous_card
+            - international_driving_licence
+            - matricula_consular
+            - municipality_identity_card
+            - national_health_insurance_card
+            - national_id
+            - national_identity_card
+            - passport
+            - passport_card
+            - postal_identity_card
+            - private_operators_card
+            - professional_qualification_card
+            - proof_of_citizenship
+            - registro_federal_de_contribuyentes
+            - residence_permit
+            - residence_status_document
+            - service_id_card
+            - social_insurance_number
+            - social_security_card
+            - social_security_number
+            - tax_id
+            - visa
+            - voter_id
+            - work_permit
+            - incorporation_number
+          description: A legal document that verifies the identity of the account owner.
+        - name: identification_value
+          in: formData
+          required: false
+          type: string
+          description: >-
+            A unique reference code for the identification document, such as a
+            passport number.
+          maxLength: 255
+        - name: terms_and_conditions_accepted
+          in: formData
+          required: false
+          type: boolean
+          description: Acceptance of the terms and conditions.
+        - name: identification_expiration
+          in: formData
+          required: false
+          type: string
+          format: date
+          description: >-
+            The expiration date for the identification information provided. Format YYYY-MM-DD. Part of extended compliance for "legal_entity_type: individual" accounts.
+        - name: identification_issuer
+          in: formData
+          required: false
+          type: string
+          maxLength: 255
+          description: >-
+            ISO country code indicating the issuer of the identification information provided. Part of extended compliance for "legal_entity_type: individual" accounts.
+        - name: legal_entity_sub_type
+          in: formData
+          required: false
+          type: string
+          description: >-
+            The type of company this account represents. Part of extended compliance for "legal_entity_type: company" accounts
+          enum:
+            - sole_trader
+            - limited_liability_company
+            - public_limited_company
+            - limited_liability_partnership
+            - unincorporated_partnership
+            - unregistered_charity
+            - registered_charity
+            - trust
+            - company_with_nominee_shareholders_or_shares_in_bearer_form
+            - scottish_limited_partnership
+            - other
+      responses:
+        '200':
+          description: Success.
+          schema:
+            $ref: '#/definitions/Account'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '400':
+          description: Client error.
+          x-errors:
+            - code: at_least_one_parameter
+              category: base
+              message: >-
+                At least one parameter should be present: account_name, brand,
+                your_reference, status, street, city, state_or_province, postal_code,
+                country, spread_table, legal_entity_type, identification_type,
+                identification_value, api_trading, online_trading, phone_trading
+                or terms_and_conditions_accepted.
+              params: '{ account_name, brand, your_reference, status, street, city, state_or_province, postal_code, country, spread_table, legal_entity_type, identification_type, identification_value, api_trading, online_trading, phone_trading, terms_and_conditions_accepted }'
+            - code: id_is_not_valid_uuid
+              category: id
+              message: id should be in UUID format
+              params: ''
+            - code: account_name_is_too_short
+              category: account_name
+              message: account_name can not be shorter than 1 character(s)
+              params: '{ "minlength" => 1}'
+            - code: account_name_is_too_long
+              category: account_name
+              message: account_name can not be longer than 150 character(s)
+              params: '{ "maxlength" => 150 }'
+            - code: account_name_is_in_invalid_format
+              category: account_name
+              message: account_name is in invalid format
+              params: ''
+            - code: brand_is_too_long
+              category: brand
+              message: brand can not be longer than 255 character(s)
+              params: '{ "maxlength" => 255 }'
+            - code: brand_not_found
+              category: brand
+              message: Brand non_existing_brand wasn't found
+              params: '{ "brand" => "non_existing_brand" }'
+            - code: brand_account_not_broker
+              category: brand
+              message: Account doesn't have broker permissions
+              params: '{ "brand" => "wrong_brand" }'
+            - code: permission_denied
+              category: permissions
+              message: Permission denied
+              params: ''
+            - code: your_reference_is_too_long
+              category: your_reference
+              message: your_reference can not be longer than 25 character(s)
+              params: '{ "maxlength" => 25 }'
+            - code: legal_entity_type_not_in_range
+              category: legal_entity_type
+              message: 'legal_entity_type should be in range: individual, company'
+              params: '{ "range" => "individual, company" }'
+            - code: status_not_in_range
+              category: status
+              message: 'status should be in range: enabled, disabled, enabled_no_trading'
+              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+            - code: street_is_too_long
+              category: street
+              message: street can not be longer than 150 character(s)
+              params: '{ "maxlength" => 150 }'
+            - code: city_is_too_long
+              category: city
+              message: city can not be longer than 100 character(s)
+              params: '{ "maxlength" => 100 }'
+            - code: postal_code_is_too_long
+              category: postal_code
+              message: postal_code can not be longer than 20 character(s)
+              params: '{ "maxlength" => 20 }'
+            - code: state_or_province_is_too_long
+              category: state_or_province
+              message: state_or_province can not be longer than 100 character(s)
+              params: '{ "maxlength" => 100 }'
+            - code: country_is_in_invalid_format
+              category: country
+              message: country is not a valid ISO 3166-1 Alpha-2 country code
+              params: '{ "type" => "country_code" }'
+            - code: spread_table_is_too_long
+              category: spread_table
+              message: spread_table can not be longer than 100 character(s)
+              params: '{ "maxlength" => 100 }'
+            - code: identification_type_is_missing
+              category: identification_type
+              message: identification_type is missing
+              params: ''
+            - code: identification_type_not_in_range
+              category: identification_type
+              message: >-
+                identification_type should be in range: none, drivers_license,
+                social_security_number, green_card, passport, visa, matricula_consular,
+                registro_federal_de_contribuyentes, credential_de_elector,
+                social_insurance_number, citizenship_papers, drivers_license_canadian,
+                existing_credit_card_details, employer_identification_number, national_id,
+                others, incorporation_number, clave_unica_de_registro_de_poblacion
+              params: '{ "range": "none, drivers_license, social_security_number, green_card, passport, visa, matricula_consular, registro_federal_de_contribuyentes, credential_de_elector, social_insurance_number, citizenship_papers, drivers_license_canadian, existing_credit_card_details, employer_identification_number, national_id, others, incorporation_number, clave_unica_de_registro_de_poblacion" }'
+            - code: identification_type_is_invalid
+              category: identification_type
+              message: identification_type is invalid
+              params: ''
+            - code: identification_value_is_missing
+              message: identification_value is missing
+              category: identification_value
+              params: ''
+            - code: identification_value_is_invalid
+              category: identification_value
+              message: identification_value is invalid
+              params: ''
+            - code: identification_value_is_too_short
+              category: identification_value
+              message: identification_value can not be shorter than 1 character(s)
+              params: ' { "minlength": 1 }'
+            - code: editing_address_not_allowed
+              category: address
+              message: You cannot edit address information. Please contact support for additional information
+              params: ''
+            - code: editing_country_not_allowed
+              category: country
+              message: You cannot edit country. Please contact support for additional information
+              params: ''
+          schema:
+            $ref: '#/definitions/UpdateAccountError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '401':
+          description: Unauthorized.
+          x-errors:
+            - code: invalid_supplied_credentials
+              category: username
+              message: Authentication failed with the supplied credentials
+              params: ''
+          schema:
+            $ref: '#/definitions/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '404':
+          description: Resource not found.
+          schema:
+            $ref: '#/definitions/NotFoundError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '429':
+          description: Too many requests.
+          x-errors:
+            - code: too_many_requests
+              category: base
+              message: >-
+                Too many requests have been made to the api. Please refer to the
+                Developer Center for more information
+              params: ''
+          schema:
+            $ref: '#/definitions/RateLimitError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '500':
+          description: Internal server error
+          x-errors:
+            - code: internal_server_error
+              category: base
+              message: Internal server error
+              params: ''
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+            - code: service_unavailable
+              category: base
+              message: Service is temporarily unavailable
+              params: ''
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
   '/accounts/{id}/compliance_settings':
     get:
       tags:
@@ -1491,7 +1491,7 @@ paths:
         returns the updated account entity.
       operationId: UpdateAccountComplianceSettings
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -2019,9 +2019,9 @@ paths:
           required: false
           type: string
           enum:
-            - yes
-            - no
-            - not required
+            - 'yes'
+            - 'no'
+            - 'not required'
           description: Has the bank account been verified?
         - name: page
           in: formData
@@ -2543,7 +2543,7 @@ paths:
             Length must be between 6 and 255 characters. <br>
             Regex:  /^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$/
           required: true
-          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
           minLength: 6
           maxLength: 255
       responses:
@@ -2977,7 +2977,7 @@ paths:
         Tops up the margin balance.
       operationId: TopUpMarginBalance
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -3774,7 +3774,7 @@ paths:
         by an update. To achieve this, you should create a new beneficiary.
       operationId: UpdateBeneficiary
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -3828,7 +3828,7 @@ paths:
           required: false
           type: string
           description: Beneficiary's email address.
-          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
           minLength: 6
           maxLength: 255
         - name: beneficiary_address
@@ -4508,7 +4508,7 @@ paths:
         Creates a new beneficiary. Returns the new beneficiary entity on success.
       operationId: CreateBeneficiary
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -4556,7 +4556,7 @@ paths:
           required: false
           type: string
           description: Email address
-          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
           minLength: 6
           maxLength: 255
         - name: beneficiary_address
@@ -5244,7 +5244,7 @@ paths:
         successful, the beneficiary's final state is returned.
       operationId: DeleteBeneficiary
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -5376,7 +5376,7 @@ paths:
         the entity that would be created if the beneficiary was saved.
       operationId: ValidateBeneficiary
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -5994,7 +5994,7 @@ paths:
         please contact your Account Manager or our support team.
       operationId: BeneficiaryAccountVerification
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -6399,7 +6399,7 @@ paths:
           required: false
           type: string
           description: The contact's email address.
-          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
           minLength: 6
           maxLength: 255
         - name: your_reference
@@ -6689,7 +6689,7 @@ paths:
         entity on success.
       operationId: UpdateContact
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -6728,7 +6728,7 @@ paths:
             Instead, an email change request flow is initiated, sending notifications to both the old and new
             email addresses. The value will be updated when the change is confirmed via a link sent to the new
             email address.
-          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
           minLength: 6
           maxLength: 255
         - name: your_reference
@@ -6987,7 +6987,7 @@ paths:
         the new contact entity on success.
       operationId: CreateContact
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -7022,7 +7022,7 @@ paths:
           required: true
           type: string
           description: The contact's email address.
-          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
+          pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}$
           minLength: 6
           maxLength: 255
         - name: phone_number
@@ -7287,9 +7287,9 @@ paths:
       summary: Generate HMAC Key for Contact
       description: >-
         Generates a new account HMAC key for the current contact.
-      operationId: GenrateHMACKey
+      operationId: GenerateHMACKey
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -7321,7 +7321,7 @@ paths:
                 Brand #{brand} should be configured first
               params: ''
           schema:
-            $ref: '#/definitions/GenrateHMACKeyError'
+            $ref: '#/definitions/GenerateHMACKeyError'
           headers:
             X-Request-Id:
               type: string
@@ -7403,7 +7403,7 @@ paths:
       description: 'Creates a new conversion. Returns the details of the created conversion on success.'
       operationId: CreateConversion
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -8338,7 +8338,7 @@ paths:
       description: 'Cancels the conversion identified by the provided unique ID {id}.'
       operationId: CancelConversion
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -8592,7 +8592,7 @@ paths:
         Changes the date of the conversion identified by the provided unique ID {id}.
       operationId: ConversionDateChange
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -8967,7 +8967,7 @@ paths:
         - name: amount
           required: true
           type: string
-          in: formData
+          in: query
           description: The amount at which to split this conversion.
           pattern: ^\d+(\.\d{1,3})?$
       responses:
@@ -9126,7 +9126,7 @@ paths:
       description: Splits the conversion specified by the unique ID {id}. Upon success, it returns the details of the parent and new child conversions.
       operationId: SplitConversion
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -9727,7 +9727,7 @@ paths:
       description: Submits a payment. On success, returns the new payment record. Use the <a href="/api-reference/#get-payer-requirements">Get Payer Requirements</a> endpoint to find out what payer information needs to be provided.<br><br> Clients who are implementing Strong Customer Authentication (SCA) for payments should refer to our <a href="../guides/integration-guides/sca_sponsored_api_payments">integration guide</a>.
       operationId: CreatePayment
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -10827,7 +10827,7 @@ paths:
       description: 'Updates a payment. On success, returns the updated payment entity.'
       operationId: UpdatePayment
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -11653,7 +11653,7 @@ paths:
       description: Authorises a payment pending authorisation.
       operationId: AuthorisePayment
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -11774,7 +11774,7 @@ paths:
       description: 'Delete a payment. On success, returns the final payment record state.'
       operationId: DeletePayment
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -12036,7 +12036,7 @@ paths:
       description: 'Assigns a <a href="https://support.currencycloud.com/hc/en-gb/articles/360017471459-Applying-fees-to-individual-payments-FAQ">payment fee</a> table to a specific sub-account.'
       operationId: PaymentsAssignPaymentFee
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -12654,7 +12654,7 @@ paths:
       description: 'Unassigns the <a href="https://support.currencycloud.com/hc/en-gb/articles/360017471459-Applying-fees-to-individual-payments-FAQ">payment fee</a> tables for a specific sub-account.'
       operationId: PaymentsUnassignPaymentFee
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -12800,7 +12800,7 @@ paths:
         <strong><a href="../guides/integration-guides/sca_sponsored_api_payments">SCA for payments integration guide</a></strong>.
       operationId: ValidatePayment
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -13974,7 +13974,7 @@ paths:
       summary: Find Bank Details
       description: >-
         Returns the related bank details for the given account reference.
-      operationId: FinfBankDetailsPost
+      operationId: FindBankDetailsPost
       produces:
         - application/json
       parameters:
@@ -15240,7 +15240,7 @@ paths:
         requested.
       operationId: GenerateConversionReport
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -15529,7 +15529,7 @@ paths:
       description: Returns a JSON structure with details of the payments report requested.
       operationId: GeneratePaymentReport
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -15798,7 +15798,7 @@ paths:
       x-api-group: manage
       summary: Find Report Requests
       description: Searches for report requests made. Returns a JSON structure with details of matching report requests.
-      operationId: Find Report Requests
+      operationId: FindReportRequests
       produces:
         - application/json
       parameters:
@@ -16029,7 +16029,7 @@ paths:
       x-api-group: manage
       summary: Retrieves a Report Request with the given ID
       description: Searches for a report by ID. Returns a JSON structure with details of the specified report request.
-      operationId: Retrieve a Report Request
+      operationId: RetrieveReportRequest
       produces:
         - application/json
       parameters:
@@ -16757,7 +16757,7 @@ paths:
         money in the same currency.
       operationId: CreateTransfer
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -17493,7 +17493,7 @@ paths:
       description: Requests that a transfer be cancelled.
       operationId: CancelTransfer
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -17638,7 +17638,7 @@ paths:
       summary: Find Withdrawal Account
       description: >-
         Lists all withdrawal accounts assigned to an account.
-      operationId: FindWithdrawlAccount
+      operationId: FindWithdrawalAccount
       produces:
         - application/json
       parameters:
@@ -17948,7 +17948,7 @@ paths:
         not implemented in the Production environment.
       operationId: SimulateFunding
       consumes:
-        - multipart/form-data
+        - application/x-www-form-urlencoded
       produces:
         - application/json
       parameters:
@@ -18559,9 +18559,9 @@ definitions:
         description: Has the bank account been verified?
         type: string
         enum:
-          - yes
-          - no
-          - not required
+          - 'yes'
+          - 'no'
+          - 'not required'
     example:
       id: B7DE235A-FF5D-4252-83C2-06A605267FEA
       account_name: Company PLC
@@ -19642,20 +19642,24 @@ definitions:
     type: object
     properties:
       parent_conversion:
-        $ref: '#/definitions/ConversionSplitDetails'
         description: The parent conversion.
+        allOf:
+          - $ref: '#/definitions/ConversionSplitDetails'
       child_conversion:
-        $ref: '#/definitions/ConversionSplitDetails'
         description: The child conversion.
+        allOf:
+          - $ref: '#/definitions/ConversionSplitDetails'
   ConversionSplitHistory:
     type: object
     properties:
       origin_conversion:
-        $ref: '#/definitions/ConversionSplitDetails'
         description: The original conversion (before split).
+        allOf:
+          - $ref: '#/definitions/ConversionSplitDetails'
       parent_conversion:
-        $ref: '#/definitions/ConversionSplitDetails'
         description: The parent conversion (after split).
+        allOf:
+          - $ref: '#/definitions/ConversionSplitDetails'
       child_conversions:
         type: array
         items:
@@ -20758,7 +20762,7 @@ definitions:
       routing_code_type: bic_swift
       created_at: '2018-05-14T14:18:30+00:00'
       updated_at: '2018-05-14T14:18:30+00:00'
-  GenrateHMACKeyError:
+  GenerateHMACKeyError:
     type: object
     description: |
       Client error information for the Contacts Generate HMAC Key endpoint.
@@ -23238,6 +23242,8 @@ definitions:
               number is the bid SPOT rate and the second is the ask SPOT rate.
       unavailable:
         type: array
+        items:
+          type: string
         description: >-
           A list of valid currency pairs that are not currently available.
     example:


### PR DESCRIPTION
## Fix Swagger 2.0 spec issues and add OpenAPI 3.0.3 definition

### Context

Customers reported breaking changes after backend validation was tightened for multipart/form-data parsing. Investigation revealed the root cause is a long-standing mismatch in `reference.yaml`: the spec declares `multipart/form-data` globally despite no endpoint handling file uploads. Customers following the spec used multipart encoding, which broke when the backend started enforcing stricter RFC 7578 parsing.

Some of the official SDKs already use `application/x-www-form-urlencoded`, confirming this is a spec documentation issue, not an API behaviour change.

### Changes to `reference.yaml` (Swagger 2.0)

**Content-type fix (critical):**
- Changed `consumes` from `multipart/form-data` to `application/x-www-form-urlencoded` globally and across 31 endpoint-level declarations
- No endpoint uses `type: file` parameters; `application/x-www-form-urlencoded` is correct for simple key-value form data and matches what the SDKs already send
- The server accepts both content types — this change aligns the spec with actual behaviour and eliminates the multipart parsing issues customers are hitting

**Spec validity fixes:**
- `GET /conversions/{id}/split_preview`: changed `amount` parameter from `in: formData` to `in: query` — formData is invalid on GET requests per the Swagger spec
- Fixed invalid email regex pattern across 6 endpoints: removed possessive quantifier `{2,}+` → `{2,}` which is not valid in standard regex engines
- Fixed `bank_account_verified` enum: quoted `yes`/`no` values to prevent YAML 1.1 boolean coercion (parser was silently converting them to `true`/`false`, mismatching `type: string`)
- Fixed `$ref` with sibling `description` on `ConversionSplit` and `ConversionSplitHistory` definitions — wrapped in `allOf` so descriptions are not silently ignored by compliant parsers
- Added missing `items: { type: string }` to `BasicRates.unavailable` array definition

**operationId fixes:**
- `GenrateHMACKey` → `GenerateHMACKey` (+ related error definition name)
- `FinfBankDetailsPost` → `FindBankDetailsPost`
- `FindWithdrawlAccount` → `FindWithdrawalAccount`
- `Find Report Requests` → `FindReportRequests` (spaces break code generators)
- `Retrieve a Report Request` → `RetrieveReportRequest`

**Formatting:**
- Fixed inconsistent indentation on `/accounts/{id}` path (~520 lines using 3-space indent instead of 4-space, the only path in the spec with non-standard indentation)

### New file: `reference-oas3.yaml` (OpenAPI 3.0.3)

Programmatic conversion of the corrected Swagger 2.0 spec to OpenAPI 3.0.3. All 79 paths, 84 operations, and 83 operationIds are preserved 1:1.

Key structural transformations:
- `host`/`basePath`/`schemes` → `servers` array
- `consumes`/`produces` → per-operation `requestBody.content` and response `content`
- 441 `in: formData` parameters across 33 endpoints → `requestBody` with typed schema objects
- `#/definitions/` → `#/components/schemas/`
- Parameter `type`/`format` → wrapped in `schema` object
- Response headers `type` → wrapped in `schema` object
- 2 unused definitions removed (`GetAuthenticatingAccountError`, `Settlement`)
- All `x-` vendor extensions preserved

Target version is 3.0.3 (not 3.1.x) for maximum tooling compatibility.

### Backwards compatibility

**No existing working integration is broken by any of these changes.** The spec is documentation — it does not control server behaviour. The server continues to accept both `multipart/form-data` and `application/x-www-form-urlencoded`.

| Scenario | Impact |
|----------|--------|
| Existing customers not regenerating clients | No impact |
| Customers regenerating from updated Swagger 2.0 | Switch to urlencoded (works), operationId method names change |
| Customers adopting OAS3 spec | Correct from the start |
| Official SDKs | Some already use urlencoded — some changes may be required |


### Validation

Both specs pass validation with zero errors:
- `reference.yaml`: valid YAML, consistent indentation, no invalid regex/enum/ref issues
- `reference-oas3.yaml`: clean on editor.swagger.io, no errors or warnings
