### PR TITLE
Add quotes endpoint and quote_id parameter to conversions

### DIFF
--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -54,6 +54,9 @@ tags:
     description: >-
       Create, search, manage and action all of your domestic and international
       payments through this API.
+  - name: Quotes
+    description: >-
+      Create held rate quotes to lock in exchange rates for future conversions.
   - name: Rates
     description: >-
       Super fast real-time access to live foreign exchange rates through the
@@ -7504,6 +7507,12 @@ paths:
             - 'default' for conversion - T+1 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC restricted currencies</a>, T+2 for all others.<br>
             - 'optimize_liquidity' for maximizing chances of getting a successful rate. Most relevant for exotic pairs.
             Conversion is T+0 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC restricted currencies</a>, and T+1 or T+2 for all others.
+        - name: quote_id
+          in: formData
+          required: false
+          type: string
+          description: The UUID of a previously created conversion quote.
+          format: uuid
 
       responses:
         '200':
@@ -13529,6 +13538,233 @@ paths:
           description: Resource not found.
           schema:
             $ref: '#/definitions/NotFoundError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '429':
+          description: Too many requests.
+          x-errors:
+            - code: too_many_requests
+              category: base
+              message: >-
+                Too many requests have been made to the api. Please refer to the
+                Developer Center for more information
+              params: ''
+          schema:
+            $ref: '#/definitions/RateLimitError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '500':
+          description: Internal server error
+          x-errors:
+            - code: internal_server_error
+              category: base
+              message: Internal server error
+              params: ''
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '503':
+          description: Service is temporary unavailable
+          x-errors:
+            - code: service_unavailable
+              category: base
+              message: Service is temporarily unavailable
+              params: ''
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        default:
+          description: Unexpected error.
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+  /quotes/create:
+    post:
+      tags:
+        - Quotes
+      x-api-group: quotes
+      summary: Create Quote
+      description: 'Requests a new quote for a given held rate period. Returns the details of the provided quote on success.'
+      operationId: CreateQuoteConversion
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: X-Auth-Token
+          in: header
+          required: true
+          type: string
+          description: Authentication token
+          minLength: 32
+        - name: buy_currency
+          in: formData
+          required: true
+          type: string
+          description: Three-character ISO code for currency purchased.
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+        - name: sell_currency
+          in: formData
+          required: true
+          type: string
+          description: Three-character ISO code for currency sold.
+          format: iso-4217
+          pattern: ^[A-Z]{3}$
+        - name: fixed_side
+          in: formData
+          required: true
+          type: string
+          enum:
+            - buy
+            - sell
+          description: Fix the buy or sell currency.
+        - name: amount
+          in: formData
+          required: true
+          type: string
+          description: Amount of the fixed buy or sell currency.
+          pattern: ^\d+(\.\d{1,3})?$
+        - name: hold_period
+          in: formData
+          required: true
+          type: string
+          description: The time window (period) for which the quote should be valid.
+        - name: conversion_date
+          in: formData
+          required: false
+          type: string
+          format: date
+          description: Earliest delivery date in UTC time zone. Format YYYY-MM-DD.
+        - name: conversion_date_preference
+          in: formData
+          required: false
+          type: string
+          enum:
+            - default
+            - earliest
+            - next_day
+            - optimize_liquidity
+          description: >-
+            Available and required only if conversion_date is not provided.<br>
+            Must be one of the following:<br>
+            - 'earliest' for earliest available conversion date. Make sure there is sufficient time to send funds to Currencycloud.<br>
+            - 'next_day' for next day available conversion date - T+1.<br>
+            - 'default' for conversion - T+1 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC restricted currencies</a>, T+2 for all others.<br>
+            - 'optimize_liquidity' for maximizing chances of getting a successful rate. Most relevant for exotic pairs.
+            Conversion is T+0 for <a href="https://support.currencycloud.com/hc/en-gb/articles/360017419080-Making-payments-to-India-Indonesia-Malaysia-and-the-Philippines-INR-IDR-MYR-PHP-FAQ">APAC restricted currencies</a>, and T+1 or T+2 for all others.
+        - name: on_behalf_of
+          in: formData
+          required: false
+          type: string
+          description: A contact UUID for the sub-account you're acting on behalf of.
+          format: uuid
+      responses:
+        '200':
+          description: Success.
+          schema:
+            $ref: '#/definitions/HeldRateQuote'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '400':
+          description: Client error.
+          x-errors:
+            - code: unique_value_parameters
+              category: base
+              message: >-
+                Following parameters should not have same values: sell_currency,
+                buy_currency
+              params: '{ "parameters" => "sell_currency, buy_currency" }'
+            - code: fixed_side_not_in_range
+              category: fixed_side
+              message: 'fixed_side should be in range: sell, buy'
+              params: '{ "range" => "sell, buy" }'
+            - code: fixed_side_is_required
+              category: fixed_side
+              message: fixed_side is required
+              params: ''
+            - code: conversion_date_type_is_wrong
+              category: conversion_date
+              message: conversion_date should be of date type
+              params: '{ "type" => "date" }'
+            - code: sell_currency_is_in_invalid_format
+              category: sell_currency
+              message: sell_currency is in invalid format
+              params: ''
+            - code: sell_currency_is_required
+              category: sell_currency
+              message: sell_currency is required
+              params: ''
+            - code: amount_type_is_wrong
+              category: amount
+              message: amount should be of numeric type
+              params: '{ "type" => "numeric" }'
+            - code: amount_is_required
+              category: amount
+              message: amount is required
+              params: ''
+            - code: amount_is_too_small
+              category: amount
+              message: amount can not be smaller than 1
+              params: '{ "minvalue" => 1 }'
+            - code: buy_currency_is_in_invalid_format
+              category: buy_currency
+              message: buy_currency is in invalid format
+              params: ''
+            - code: buy_currency_is_required
+              category: buy_currency
+              message: buy_currency is required
+              params: ''
+            - code: on_behalf_of_self
+              category: on_behalf_of
+              message: You cannot act on behalf of your own Contact
+              params: ''
+            - code: contact_not_found
+              category: on_behalf_of
+              message: Contact was not found for this id
+              params: ''
+            - code: amount_is_in_invalid_format
+              category: amount
+              message: amount should be of numeric type with 2 dp
+              params: '{ "type" => "numeric_with_precision", "precision" => 2 }'
+            - code: invalid_conversion_date_preference
+              category: base
+              message: not a valid conversion date preference, possible options are earliest, optimize_liquidity, default, next_day
+              params: ''
+            - code: hold_period_is_required
+              category: hold_period
+              message: hold_period is required
+              params: ''
+          schema:
+            $ref: '#/definitions/HeldRateQuoteError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '401':
+          description: Unauthorized.
+          x-errors:
+            - code: invalid_supplied_credentials
+              category: username
+              message: Authentication failed with the supplied credentials
+              params: ''
+          schema:
+            $ref: '#/definitions/UnauthorizedError'
+          headers:
+            X-Request-Id:
+              type: string
+              description: A unique reference for the request.
+        '404':
+          description: Resource not found.
           headers:
             X-Request-Id:
               type: string
@@ -19661,6 +19897,138 @@ definitions:
         items:
           $ref: '#/definitions/ConversionSplitDetails'
         description: The child conversion (after split).
+  HeldRateQuote:
+    type: object
+    description: Detailed held rate quote information.
+    properties:
+      buy_currency:
+        type: string
+        description: Three-character ISO code for currency purchased.
+      client_buy_amount:
+        type: string
+        description: Amount of currency purchased by the client.
+      client_rate:
+        type: string
+        description: Exchange rate offered to the client.
+      client_sell_amount:
+        type: string
+        description: Amount of currency sold by the client.
+      core_rate:
+        type: string
+        description: Core exchange rate.
+      created_at:
+        type: string
+        format: date-time
+        description: Date and time the quote was created.
+      currency_pair:
+        type: string
+        description: Currency pair for the conversion (e.g., EURUSD).
+      deposit_amount:
+        type: string
+        description: Deposit amount required.
+      deposit_currency:
+        type: string
+        description: Currency for the deposit.
+      deposit_required:
+        type: boolean
+        description: Whether a deposit is required.
+      expires_at:
+        type: string
+        format: date-time
+        description: Date and time when the quote expires.
+      fixed_side:
+        type: string
+        enum:
+          - buy
+          - sell
+        description: Which side of the conversion is fixed.
+      mid_market_rate:
+        type: string
+        description: Mid-market exchange rate.
+      partner_buy_amount:
+        type: string
+        description: Amount of currency purchased by the partner.
+      partner_rate:
+        type: string
+        description: Exchange rate for the partner.
+      partner_sell_amount:
+        type: string
+        description: Amount of currency sold by the partner.
+      quote_id:
+        type: string
+        format: uuid
+        description: Unique identifier for the quote.
+      sell_currency:
+        type: string
+        description: Three-character ISO code for currency sold.
+      settlement_cut_off_time:
+        type: string
+        format: date-time
+        description: Cut-off time for settlement.
+    example:
+      buy_currency: 'USD'
+      client_buy_amount: '118.56'
+      client_rate: '1.1856'
+      client_sell_amount: '100.0'
+      core_rate: '1.1858'
+      created_at: '2025-08-11T08:10:21Z'
+      currency_pair: 'EURUSD'
+      deposit_amount: '0.0'
+      deposit_currency: 'EUR'
+      deposit_required: false
+      expires_at: '2025-08-11T08:15:21Z'
+      fixed_side: 'sell'
+      mid_market_rate: '1.0146'
+      partner_buy_amount: '118.56'
+      partner_rate: '1.1856'
+      partner_sell_amount: '100.0'
+      quote_id: '3c25ce4a-3552-45bb-869e-406c795052aa'
+      sell_currency: 'EUR'
+      settlement_cut_off_time: '2025-08-13T15:30:00Z'
+  HeldRateQuoteError:
+    type: object
+    description: Client error information for the Create Quote endpoint.
+    required:
+      - error_code
+      - error_messages
+    properties:
+      error_code:
+        type: string
+        description: A high-level error code for the whole request.
+      error_messages:
+        type: object
+        description: >-
+          Detailed error information for individual input parameters that failed
+          validation. Object keys are the names of the invalid input parameters.
+          Each parameter may have one or more reasons why it failed.
+        additionalProperties:
+          type: array
+          items:
+            type: object
+            description: >-
+              An object that represents one of the reasons why the input
+              parameter failed.
+            required:
+              - code
+              - message
+            properties:
+              code:
+                type: string
+                description: >-
+                  A unique code that identifies this error. It can be used for
+                  translations.
+              message:
+                type: string
+                description: An explanation of the error in English.
+              params:
+                type: object
+                default: { }
+                description: >-
+                  Relevant validation rules that failed. This can be used for
+                  translations.
+                example:
+                  minlength: 1
+                  maxlength: 255
   ReportRequest:
     type: object
     description: Report record


### PR DESCRIPTION
## Summary
This PR adds the new quotes functionality to the public API documentation:

1. **New `/v2/quotes/create` endpoint** - Allows clients to request held rate quotes for currency conversions
2. **New `quote_id` parameter** on `/v2/conversions/create` - Enables conversions to use previously created quotes
3. **New `Quotes` tag** in API documentation
4. **New schema definitions** - `HeldRateQuote` and `HeldRateQuoteError`

## Background
These endpoints were introduced in the private swagger and are now being exposed to the public API to allow clients to lock in exchange rates for a specified period before executing conversions.

## Changes
- Added Quotes tag to the tags section
- Added complete `/quotes/create` endpoint with all parameters, responses, and error codes  
- Extended `/conversions/create` endpoint with optional `quote_id` parameter
- Added `HeldRateQuote` and `HeldRateQuoteError` definitions to the definitions section

## Documentation Team Review
Please review these additions for:
- Accuracy of descriptions and parameter documentation
- Consistency with existing API documentation style
- Any additional examples or clarifications needed