### PR TITLE
chore: merge master into pilot_testing

### DIFF
--- a/src/pt_br/reference_pt_br.yaml
+++ b/src/pt_br/reference_pt_br.yaml
@@ -346,7 +346,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - "enabled_no_trading"
           default: enabled
           description: Status da conta.
         - name: "state_or_province"
@@ -777,7 +776,6 @@ paths:
         enum:
           - disabled
           - enabled
-          - "enabled_no_trading"
         default: enabled
         description: Status da conta.
       - name: street
@@ -1177,7 +1175,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - "enabled_no_trading"
           description: Status da conta.
         - name: street
           in: formData
@@ -16648,7 +16645,6 @@ definitions:
         enum:
           - disabled
           - enabled
-          - "enabled_no_trading"
         description: Status da conta
       street:
         type: string

--- a/src/pt_br/reference_pt_br.yaml
+++ b/src/pt_br/reference_pt_br.yaml
@@ -2907,7 +2907,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Endereço de e-mail do beneficiário.
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            Endereço de e-mail do beneficiário.
+          deprecated: true
         - name: "beneficiary_address"
           in: formData
           required: false
@@ -3101,7 +3105,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Natureza do negócio do beneficiário.
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            Natureza do negócio do beneficiário.
+          deprecated: true
         - name: "company_website"
           in: formData
           required: false
@@ -3568,7 +3576,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Endereço de e-mail
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            Endereço de e-mail
+          deprecated: true
         - name: "beneficiary_address"
           in: formData
           required: false
@@ -3761,7 +3773,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Natureza do negócio do beneficiário.
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            Natureza do negócio do beneficiário.
+          deprecated: true
         - name: "company_website"
           in: formData
           required: false
@@ -8522,7 +8538,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: "O nome do beneficiário final, se for diferente."
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            O nome do beneficiário final, se for diferente.
+          deprecated: true
         - name: "purpose_code"
           in: formData
           required: false
@@ -9523,7 +9543,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: "O nome do beneficiário final, se for diferente."
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            O nome do beneficiário final, se for diferente.
+          deprecated: true
         - name: "purpose_code"
           in: formData
           required: false
@@ -11519,7 +11543,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: "O nome do beneficiário final, se for diferente."
+          description: >-
+            <span style="color:#FF5000;">OBSOLETO</span>. Este campo está
+            obsoleto e será removido em 26 de novembro de 2026.<br>
+            O nome do beneficiário final, se for diferente.
+          deprecated: true
         - name: "purpose_code"
           in: formData
           required: false

--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -402,7 +402,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - enabled_no_trading
           default: enabled
           description: Account status.
         - name: state_or_province
@@ -691,8 +690,8 @@ paths:
               params: '{ "maxlength" => 25 }'
             - code: status_not_in_range
               category: status
-              message: 'status should be in range: enabled, disabled, enabled_no_trading'
-              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+              message: 'status should be in range: enabled, disabled'
+              params: '{ "range" => "enabled, disabled" }'
             - code: legal_entity_type_not_in_range
               category: legal_entity_type
               message: 'legal_entity_type should be in range: individual, company'
@@ -1016,7 +1015,6 @@ paths:
         enum:
           - disabled
           - enabled
-          - enabled_no_trading
         default: enabled
         description: Status of the account.
       - name: street
@@ -1221,8 +1219,8 @@ paths:
             params: '{ "range" => "individual, company" }'
           - code: status_not_in_range
             category: status
-            message: 'status should be in range: enabled, disabled, enabled_no_trading'
-            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+            message: 'status should be in range: enabled, disabled'
+            params: '{ "range" => "enabled, disabled" }'
           - code: street_is_too_long
             category: street
             message: street can not be longer than 150 character(s)
@@ -1978,7 +1976,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - enabled_no_trading
           description: Account status.
         - name: street
           in: formData
@@ -2100,8 +2097,8 @@ paths:
               params: '{ "maxlength" => 25 }'
             - code: status_not_in_range
               category: status
-              message: 'status should be in range: enabled, disabled, enabled_no_trading'
-              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+              message: 'status should be in range: enabled, disabled'
+              params: '{ "range" => "enabled, disabled" }'
             - code: invalid_extra_parameters
               category: legal_entity_type
               message: 'Invalid extra parameters: ${legal_entity_type}'
@@ -18711,7 +18708,6 @@ definitions:
         enum:
           - disabled
           - enabled
-          - enabled_no_trading
         description: Account status
       street:
         type: string

--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -3827,7 +3827,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Beneficiary's email address.
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            Beneficiary's email address.
+          deprecated: true
           pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
           minLength: 6
           maxLength: 255
@@ -4062,7 +4066,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Beneficiary nature of business.
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            Beneficiary nature of business.
+          deprecated: true
           maxLength: 255
         - name: company_website
           in: formData
@@ -4555,7 +4563,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Email address
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            Email address
+          deprecated: true
           pattern: ^[\w\.\_\%\-\+]+@([\w-]+\.)+\w{2,}+$
           minLength: 6
           maxLength: 255
@@ -4792,7 +4804,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: Beneficiary nature of business.
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            Beneficiary nature of business.
+          deprecated: true
           maxLength: 255
         - name: company_website
           in: formData
@@ -9933,7 +9949,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: The name of the ultimate beneficiary if different.
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            The name of the ultimate beneficiary if different.
+          deprecated: true
           minLength: 1
           maxLength: 255
         - name: purpose_code
@@ -11019,7 +11039,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: The name of the ultimate beneficiary if different.
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            The name of the ultimate beneficiary if different.
+          deprecated: true
           minLength: 1
           maxLength: 255
         - name: purpose_code
@@ -13004,7 +13028,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: The name of the ultimate beneficiary if different.
+          description: >-
+            <span style="color:#FF5000;">DEPRECATED</span>. This field is
+            deprecated and will be removed on 26 November 2026.<br>
+            The name of the ultimate beneficiary if different.
+          deprecated: true
           minLength: 1
           maxLength: 255
         - name: purpose_code

--- a/src/reference.yaml
+++ b/src/reference.yaml
@@ -3768,6 +3768,10 @@ paths:
       x-api-group: pay
       summary: Update Beneficiary
       description: >-
+        <p style="border-width:3px; border-style:solid; border-color:#FF5000; padding: 1em;">
+        Deprecation Notice: Request fields <strong>email</strong> and <strong>business_nature</strong> are deprecated and should no longer be used.
+        They will be removed on 26 November 2026<br></p><br>
+
         Updates an existing beneficiary. Returns the updated
         beneficiary entity on success. <br>
         Please note that it's not possible to change a beneficiary's entity type (company or individual)
@@ -4513,6 +4517,9 @@ paths:
       x-api-group: pay
       summary: Create Beneficiary
       description: >-
+        <p style="border-width:3px; border-style:solid; border-color:#FF5000; padding: 1em;">
+        Deprecation Notice: Request fields <strong>email</strong> and <strong>business_nature</strong> are deprecated and should no longer be used.
+        They will be removed on 26 November 2026<br></p><br>
         Creates a new beneficiary. Returns the new beneficiary entity on success.
       operationId: CreateBeneficiary
       consumes:
@@ -9745,7 +9752,12 @@ paths:
         - Payments
       x-api-group: pay
       summary: Create Payment
-      description: Submits a payment. On success, returns the new payment record. Use the <a href="/api-reference/#get-payer-requirements">Get Payer Requirements</a> endpoint to find out what payer information needs to be provided.<br><br> Clients who are implementing Strong Customer Authentication (SCA) for payments should refer to our <a href="../guides/integration-guides/sca_sponsored_api_payments">integration guide</a>.
+      description: >-
+        <p style="border-width:3px; border-style:solid; border-color:#FF5000; padding: 1em;">
+        Deprecation Notice: Request field <strong>ultimate_beneficiary_name</strong> is deprecated and should no longer be used.
+        It will be removed on 26 November 2026<br></p><br>
+
+        Submits a payment. On success, returns the new payment record. Use the <a href="/api-reference/#get-payer-requirements">Get Payer Requirements</a> endpoint to find out what payer information needs to be provided.<br><br> Clients who are implementing Strong Customer Authentication (SCA) for payments should refer to our <a href="../guides/integration-guides/sca_sponsored_api_payments">integration guide</a>.
       operationId: CreatePayment
       consumes:
         - multipart/form-data
@@ -10849,7 +10861,11 @@ paths:
         - Payments
       x-api-group: pay
       summary: Update Payment
-      description: 'Updates a payment. On success, returns the updated payment entity.'
+      description: >-
+        <p style="border-width:3px; border-style:solid; border-color:#FF5000; padding: 1em;">
+        Deprecation Notice: Request field <strong>ultimate_beneficiary_name</strong> is deprecated and should no longer be used.
+        It will be removed on 26 November 2026<br></p><br>
+        'Updates a payment. On success, returns the updated payment entity.'
       operationId: UpdatePayment
       consumes:
         - multipart/form-data
@@ -12820,6 +12836,10 @@ paths:
       x-api-group: pay
       summary: Validate Payment
       description: >-
+        <p style="border-width:3px; border-style:solid; border-color:#FF5000; padding: 1em;">
+        Deprecation Notice: Request field <strong>ultimate_beneficiary_name</strong> is deprecated and should no longer be used.
+        It will be removed on 26 November 2026<br></p><br>
+
         Validates the details of a new payment without creating a
         record of the payment. On success, returns an object containing
         a string validation_result with value "success".<br><br>
@@ -15814,7 +15834,8 @@ paths:
         - Reporting
       x-api-group: manage
       summary: Generate Payment Report
-      description: Returns a JSON structure with details of the payments report requested.
+      description: >-
+        Returns a JSON structure with details of the payments report requested.
       operationId: GeneratePaymentReport
       consumes:
         - multipart/form-data

--- a/src/zh_cn/reference_zh_cn.yaml
+++ b/src/zh_cn/reference_zh_cn.yaml
@@ -346,7 +346,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - enabled_no_trading
           default: enabled
           description: 账户状态。
         - name: state_or_province
@@ -455,8 +454,8 @@ paths:
               params: '{ "maxlength" => 25 }'
             - code: status_not_in_range
               category: status
-              message: 'status 应在此范围内：enabled, disabled, enabled_no_trading'
-              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+              message: 'status 应在此范围内：enabled, disabled'
+              params: '{ "range" => "enabled, disabled" }'
             - code: legal_entity_type_not_in_range
               category: legal_entity_type
               message: 'legal_entity_type 应在此范围内：individual, company'
@@ -777,7 +776,6 @@ paths:
         enum:
           - disabled
           - enabled
-          - enabled_no_trading
         default: enabled
         description: 账户状态。
       - name: street
@@ -923,8 +921,8 @@ paths:
             params: '{ "range" => "individual, company" }'
           - code: status_not_in_range
             category: status
-            message: 'status 应在此范围内：enabled, disabled, enabled_no_trading'
-            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+            message: 'status 应在此范围内：enabled, disabled'
+            params: '{ "range" => "enabled, disabled" }'
           - code: street_is_too_long
             category: street
             message: street 长度不可超过 150 个字符
@@ -1177,7 +1175,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - enabled_no_trading
           description: 账户状态。
         - name: street
           in: formData
@@ -1288,8 +1285,8 @@ paths:
               params: '{ "maxlength" => 25 }'
             - code: status_not_in_range
               category: status
-              message: 'status 应在此范围内：enabled, disabled, enabled_no_trading'
-              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+              message: 'status 应在此范围内：enabled, disabled'
+              params: '{ "range" => "enabled, disabled" }'
             - code: invalid_extra_parameters
               category: legal_entity_type
               message: '无效的额外参数：${legal_entity_type}'
@@ -16476,7 +16473,6 @@ definitions:
         enum:
           - disabled
           - enabled
-          - enabled_no_trading
         description: 账户状态
       street:
         type: string

--- a/src/zh_cn/reference_zh_cn.yaml
+++ b/src/zh_cn/reference_zh_cn.yaml
@@ -2903,7 +2903,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 收款人的电子邮件地址。
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            收款人的电子邮件地址。
+          deprecated: true
         - name: beneficiary_address
           in: formData
           required: false
@@ -3097,7 +3101,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 收款人业务性质。
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            收款人业务性质。
+          deprecated: true
         - name: company_website
           in: formData
           required: false
@@ -3561,7 +3569,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 电子邮件地址
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            电子邮件地址
+          deprecated: true
         - name: beneficiary_address
           in: formData
           required: false
@@ -3754,7 +3766,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 收款人业务性质。
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            收款人业务性质。
+          deprecated: true
         - name: company_website
           in: formData
           required: false
@@ -8376,7 +8392,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 最终收款人的名称（如果不同）。
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            最终收款人的名称（如果不同）。
+          deprecated: true
         - name: purpose_code
           in: formData
           required: false
@@ -9370,7 +9390,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 最终收款人的名称（如果不同）。
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            最终收款人的名称（如果不同）。
+          deprecated: true
         - name: purpose_code
           in: formData
           required: false
@@ -11238,7 +11262,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 最终收款人的名称（如果不同）。
+          description: >-
+            <span style="color:#FF5000;">已弃用</span>。此字段已弃用，将于
+            2026年11月26日移除<br>
+            最终收款人的名称（如果不同）。
+          deprecated: true
         - name: purpose_code
           in: formData
           required: false

--- a/src/zh_hk/reference_zh_hk.yaml
+++ b/src/zh_hk/reference_zh_hk.yaml
@@ -346,7 +346,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - enabled_no_trading
           default: enabled
           description: 賬戶狀態。
         - name: state_or_province
@@ -455,8 +454,8 @@ paths:
               params: '{ "maxlength" => 25 }'
             - code: status_not_in_range
               category: status
-              message: 'status 應在以下範圍內選擇：enabled、disabled、enabled_no_trading'
-              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+              message: 'status 應在以下範圍內選擇：enabled、disabled'
+              params: '{ "range" => "enabled, disabled" }'
             - code: legal_entity_type_not_in_range
               category: legal_entity_type
               message: 'legal_entity_type 應在以下範圍內選擇：individual、company'
@@ -777,7 +776,6 @@ paths:
         enum:
           - disabled
           - enabled
-          - enabled_no_trading
         default: enabled
         description: 賬戶的狀態。
       - name: street
@@ -923,8 +921,8 @@ paths:
             params: '{ "range" => "individual, company" }'
           - code: status_not_in_range
             category: status
-            message: 'status 應在以下範圍內選擇：enabled、disabled、enabled_no_trading'
-            params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+            message: 'status 應在以下範圍內選擇：enabled、disabled'
+            params: '{ "range" => "enabled, disabled" }'
           - code: street_is_too_long
             category: street
             message: street 長度不能超過 150 個字符
@@ -1177,7 +1175,6 @@ paths:
           enum:
             - disabled
             - enabled
-            - enabled_no_trading
           description: 賬戶狀態。
         - name: street
           in: formData
@@ -1288,8 +1285,8 @@ paths:
               params: '{ "maxlength" => 25 }'
             - code: status_not_in_range
               category: status
-              message: 'status 應在以下範圍內選擇：enabled、disabled、enabled_no_trading'
-              params: '{ "range" => "enabled, disabled, enabled_no_trading" }'
+              message: 'status 應在以下範圍內選擇：enabled、disabled'
+              params: '{ "range" => "enabled, disabled" }'
             - code: invalid_extra_parameters
               category: legal_entity_type
               message: '無效的額外參數：${legal_entity_type}'
@@ -16485,7 +16482,6 @@ definitions:
         enum:
           - disabled
           - enabled
-          - enabled_no_trading
         description: 賬戶狀態
       street:
         type: string

--- a/src/zh_hk/reference_zh_hk.yaml
+++ b/src/zh_hk/reference_zh_hk.yaml
@@ -2903,7 +2903,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 收款人的電子郵件地址。
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            收款人的電子郵件地址。
+          deprecated: true
         - name: beneficiary_address
           in: formData
           required: false
@@ -3097,7 +3101,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 收款人業務性質。
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            收款人業務性質。
+          deprecated: true
         - name: company_website
           in: formData
           required: false
@@ -3561,7 +3569,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 電子郵件地址
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            電子郵件地址
+          deprecated: true
         - name: beneficiary_address
           in: formData
           required: false
@@ -3754,7 +3766,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 收款人業務性質。
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            收款人業務性質。
+          deprecated: true
         - name: company_website
           in: formData
           required: false
@@ -8375,7 +8391,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 如果不同，則為最終收款人的姓名。
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            如果不同，則為最終收款人的姓名。
+          deprecated: true
         - name: purpose_code
           in: formData
           required: false
@@ -9368,7 +9388,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 如果不同，則為最終收款人的姓名。
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            如果不同，則為最終收款人的姓名。
+          deprecated: true
         - name: purpose_code
           in: formData
           required: false
@@ -11237,7 +11261,11 @@ paths:
           in: formData
           required: false
           type: string
-          description: 如果不同，則為最終收款人的姓名。
+          description: >-
+            <span style="color:#FF5000;">已棄用</span>。此欄位已棄用，將於
+            2026年11月26日移除<br>
+            如果不同，則為最終收款人的姓名。
+          deprecated: true
         - name: purpose_code
           in: formData
           required: false


### PR DESCRIPTION
## Summary

Brings `pilot_testing` back in sync with `master`. The branch was 5 commits behind; this merges `upstream/master` (`9f741c4`) in so it is no longer behind.

Merged cleanly with the `ort` strategy — no conflicts. `src/reference.yaml` auto-merged.

## What comes in from master

- #402 SWAGGER-386 — deprecates beneficiary fields + endpoint-level deprecation notice
- #401 SWAGGER-344 — removes `enabled_no_trading` account status

## Verification

- `enabled_no_trading` no longer present in `src/reference.yaml`
- The TLCOLH-924 `ultimate_sender_name` additions already on `pilot_testing` are intact
- After the merge, `pilot_testing` differs from `master` only by the TLCOLH-924 changes:
  - `data/local/swagger/responses/v2_funding_transactions_id_GET_200.json`
  - `src/reference.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)